### PR TITLE
Add ISSUE_TEMPLATE files

### DIFF
--- a/.github/ISSUE_TEMPLATE/00-feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/00-feature-request.yml
@@ -1,0 +1,23 @@
+name: Feature Request
+description: Requests for new ssl-core library features.
+title: "[Feature Request] Description"
+labels: ["feature request"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ⚠️ Before submitting your request, please review past submissions to ensure that it is not a duplicate of a known feature request.
+  - type: textarea
+    id: fr-descrip
+    attributes:
+      label: Describe the feature request
+      placeholder: A clear and concise description of the feature you would like, why it should be added, and any alternative solutions or features you've considered.
+    validations:
+      required: true
+  - type: textarea
+    id: use-case
+    attributes:
+      label: Describe scenario use case
+      placeholder: The capability and/or customer usage scenario this request supports.
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/00-feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/00-feature-request.yml
@@ -17,7 +17,7 @@ body:
   - type: textarea
     id: use-case
     attributes:
-      label: Describe scenario use case
+      label: Describe the scenario use case
       placeholder: The capability and/or customer usage scenario this request supports.
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/00-feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/00-feature-request.yml
@@ -6,7 +6,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        :warning **Before submitting your request, please review past submissions to ensure that it is not a duplicate of a known feature request.**
+        :warning: **Before submitting your request, please review past submissions to ensure that it is not a duplicate of a known feature request.**
   - type: textarea
     id: fr-descrip
     attributes:

--- a/.github/ISSUE_TEMPLATE/00-feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/00-feature-request.yml
@@ -6,18 +6,18 @@ body:
   - type: markdown
     attributes:
       value: |
-        ⚠️ Before submitting your request, please review past submissions to ensure that it is not a duplicate of a known feature request.
+        :warning **Before submitting your request, please review past submissions to ensure that it is not a duplicate of a known feature request.**
   - type: textarea
     id: fr-descrip
     attributes:
-      label: Describe the feature request
+      label: Describe the feature request.
       placeholder: A clear and concise description of the feature you would like, why it should be added, and any alternative solutions or features you've considered.
     validations:
       required: true
   - type: textarea
     id: use-case
     attributes:
-      label: Describe the scenario use case
-      placeholder: The capability and/or customer usage scenario this request supports.
+      label: Describe the scenario use case.
+      placeholder: The capability and/or scenario usage this request supports.
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/01-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/01-bug-report.yml
@@ -13,30 +13,16 @@ body:
     id: steps
     attributes:
       label: Steps to reproduce the problem
-      description: It is important that we are able to reproduce the problem that you are experiencing. Please provide all code and relevant steps to reproduce the problem, including your `CMakeLists.txt` file and build commands. Links to a GitHub branch that demonstrate the problem are also helpful.
-    validations:
-      required: true
-  - type: textarea
-    id: version
-    attributes:
-      label: What version of ssl-core are you using?
-      description: Please include the output of `git rev-parse HEAD` or the name of the LTS release that you are using.
+      description: It is important that we are able to reproduce the problem that you are experiencing. Please provide all code and relevant steps to reproduce the problem, including your build configuration file and build commands. Links to a GitHub branch that demonstrate the problem are also helpful.
     validations:
       required: true
   - type: textarea
     id: os
     attributes:
-      label: What operating system and version are you using?
-      description: If you are using a Linux distribution please include the name and version of the distribution as well.
+      label: Docker image name and tag
+      description: If you are using a custom docker image, please provide your Dockerfile.
     validations:
-      required: true
-  - type: textarea
-    id: compiler
-    attributes:
-      label: What compiler and version are you using?
-      description: Please include the output of `gcc -v` or `clang -v`, or the equivalent for your compiler.
-    validations:
-      required: true
+      required: false
   - type: textarea
     id: additional
     attributes:

--- a/.github/ISSUE_TEMPLATE/01-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/01-bug-report.yml
@@ -5,28 +5,28 @@ body:
   - type: textarea
     id: what-happened
     attributes:
-      label: Describe the issue
+      label: Describe the issue.
       description: What happened, and what did you expect to happen?
     validations:
       required: true
   - type: textarea
     id: steps
     attributes:
-      label: Steps to reproduce the problem
+      label: Describe the needed steps to reproduce the problem.
       description: It is important that we are able to reproduce the problem that you are experiencing. Please provide all code and relevant steps to reproduce the problem, including your build configuration file and build commands. Links to a GitHub branch that demonstrate the problem are also helpful.
     validations:
       required: true
   - type: textarea
     id: os
     attributes:
-      label: Docker image name and tag
+      label: Describe the used docker image name and tag.
       description: If you are using a custom docker image, please provide your Dockerfile.
     validations:
       required: false
   - type: textarea
     id: additional
     attributes:
-      label: Additional context
+      label: Describe additional context.
       description: Add any other context about the problem here.
     validations:
       required: false

--- a/.github/ISSUE_TEMPLATE/01-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/01-bug-report.yml
@@ -26,7 +26,7 @@ body:
   - type: textarea
     id: additional
     attributes:
-      label: Describe additional context.
-      description: Add any other context about the problem here.
+      label: Provide additional context.
+      description: Add any other contextual information about the problem here to support debugging.
     validations:
       required: false

--- a/.github/ISSUE_TEMPLATE/01-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/01-bug-report.yml
@@ -1,0 +1,46 @@
+name: Bug Report
+description: Let us know that something does not work as expected.
+title: "[Bug]: Please title this bug report"
+body:
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: Describe the issue
+      description: What happened, and what did you expect to happen?
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce the problem
+      description: It is important that we are able to reproduce the problem that you are experiencing. Please provide all code and relevant steps to reproduce the problem, including your `CMakeLists.txt` file and build commands. Links to a GitHub branch that demonstrate the problem are also helpful.
+    validations:
+      required: true
+  - type: textarea
+    id: version
+    attributes:
+      label: What version of ssl-core are you using?
+      description: Please include the output of `git rev-parse HEAD` or the name of the LTS release that you are using.
+    validations:
+      required: true
+  - type: textarea
+    id: os
+    attributes:
+      label: What operating system and version are you using?
+      description: If you are using a Linux distribution please include the name and version of the distribution as well.
+    validations:
+      required: true
+  - type: textarea
+    id: compiler
+    attributes:
+      label: What compiler and version are you using?
+      description: Please include the output of `gcc -v` or `clang -v`, or the equivalent for your compiler.
+    validations:
+      required: true
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional context
+      description: Add any other context about the problem here.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false


### PR DESCRIPTION
This pull request introduces the addition of two issue templates, feature requests and bug reports.

Having standard templates to issues can help readability of requests. One special feature I find appealing is the usage of `required` fields, especially on bug reports; with it we can choose required data that must always be in some type of issue.