### PR TITLE
Add Buf linter and formatting checker CI

### DIFF
--- a/.github/workflows/lint-and-formatting-checker.yaml
+++ b/.github/workflows/lint-and-formatting-checker.yaml
@@ -1,0 +1,34 @@
+name: "Buf: Lint and Formatting Checker"
+on: [pull_request]
+
+jobs:
+  lint-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: bufbuild/buf-setup-action@v1
+        with:
+          github_token: ${{ github.token }}
+          version: "1.20.0"
+      - uses: bufbuild/buf-lint-action@v1
+        with:
+          input: "protocols"
+      - uses: bufbuild/buf-breaking-action@v1
+        with:
+          input: "protocols"
+          against: "https://github.com/${GITHUB_REPOSITORY}.git#branch=main,subdir=protocols"
+
+  formatting-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: bufbuild/buf-setup-action@v1
+        with:
+          github_token: ${{ github.token }}
+          version: "1.20.0"
+      - run: |
+          buf format -d --exit-code
+          if [ $? -ne 0 ]; then
+            echo "buf format failed, please run 'buf format protocols -w' locally in the project root and commit the changes."
+            exit 1
+          fi

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 [![RobôCIn](https://img.shields.io/badge/🇧🇷-RobôCIn-009B3A)](https://robocin.com.br)
 [![Issues](https://img.shields.io/github/issues/robocin/ssl-core)](https://github.com/robocin/ssl-core/issues)
+[![Lint and Formatting Checker](https://github.com/robocin/ssl-core/actions/workflows/lint-and-formatting-checker.yaml/badge.svg?branch=main)](https://github.com/robocin/ssl-core/actions/workflows/lint-and-formatting-checker.yaml?query=branch%3Amain)
 [![Pull Requests](https://img.shields.io/github/issues-pr/robocin/ssl-core)](https://github.com/robocin/ssl-core/pulls)
 [![C++](https://img.shields.io/badge/C%2B%2B-20%2B-darkblue.svg)](https://en.cppreference.com/w/cpp/20)
 [![CMake](https://img.shields.io/badge/CMake-3.28%2B-blue.svg)](https://cmake.org/cmake/help/latest/release/3.28.html)

--- a/common/cpp/.devcontainer/devcontainer.json
+++ b/common/cpp/.devcontainer/devcontainer.json
@@ -25,8 +25,8 @@
         "streetsidesoftware.code-spell-checker",
         // YAML
         "redhat.vscode-yaml",
-        // Protobuf Language Support
-        "zxh404.vscode-proto3",
+        // Buf - Protobuf Language Support
+        "bufbuild.vscode-buf",
         // Python
         "ms-python.python"
       ],

--- a/protocols/buf.yaml
+++ b/protocols/buf.yaml
@@ -1,0 +1,14 @@
+version: v1
+lint:
+  use:
+    - DEFAULT
+
+  except:
+    - PACKAGE_VERSION_SUFFIX
+
+  ignore:
+    - protocols/third_party
+
+breaking:
+  use:
+    - FILE


### PR DESCRIPTION
This pull request introduces a linter and formatting checker for Protobuf files within the 'protocols' folder. The addition enhances code consistency and adherence to best practices.

References:
 * https://buf.build/docs/lint/usage;
 * https://buf.build/docs/configuration/v1/buf-yaml;
 * https://buf.build/docs/reference/cli/buf/format;
 * https://buf.build/docs/breaking/overview#within-subdirectories;