### PR TITLE
Fix .cmake/project.cmake rule

### DIFF
--- a/.cmake/project.cmake
+++ b/.cmake/project.cmake
@@ -57,7 +57,7 @@ macro(robocin_cpp_project_setup)
       message(STATUS "Source directory: '${CMAKE_CURRENT_LIST_DIR}/${SOURCE_DIRECTORY}'")
 
       # add all subdirectories of the source directory recursively
-      file(GLOB_RECURSE CMAKELISTS_FILES ${CMAKE_CURRENT_LIST_DIR}/${SOURCE_DIRECTORY}/**/CMakeLists.txt)
+      file(GLOB_RECURSE CMAKELISTS_FILES ${CMAKE_CURRENT_LIST_DIR}/${SOURCE_DIRECTORY}/CMakeLists.txt ${CMAKE_CURRENT_LIST_DIR}/${SOURCE_DIRECTORY}/**/CMakeLists.txt)
       foreach (CMAKELISTS_FILE ${CMAKELISTS_FILES})
         get_filename_component(CMAKELISTS_FILE_PATH ${CMAKELISTS_FILE} DIRECTORY)
         add_subdirectory(${CMAKELISTS_FILE_PATH})


### PR DESCRIPTION
#28 additionally, also add all existing subdirectories by default inside the source folder, but forgot to include the source folder itself.

This PR fixes this behavior.