### PR TITLE
Fix .cmake/project.cmake rules and update common/cpp/ library

### DIFF
--- a/.cmake/essentials.cmake
+++ b/.cmake/essentials.cmake
@@ -185,8 +185,7 @@ function(robocin_cpp_library)
 
   # add include directories of dependencies to the library (required for modules installation)
   foreach (DEP ${ARG_DEPS})
-    get_target_property(dep_include_dirs ${DEP} INTERFACE_INCLUDE_DIRECTORIES)
-    target_include_directories(${ARG_NAME} PRIVATE ${dep_include_dirs})
+    target_include_directories(${ARG_NAME} PRIVATE $<TARGET_PROPERTY:${DEP},INTERFACE_INCLUDE_DIRECTORIES>)
   endforeach ()
 
   target_compile_definitions(${ARG_NAME} PRIVATE ROBOCIN_PROJECT_NAME="${ROBOCIN_PROJECT_NAME}")

--- a/.cmake/project.cmake
+++ b/.cmake/project.cmake
@@ -53,11 +53,12 @@ macro(robocin_cpp_project_setup)
       set(SOURCE_DIRECTORY ${ROBOCIN_PROJECT_NAME})
     endif ()
 
-    if (EXISTS ${CMAKE_CURRENT_LIST_DIR}/${SOURCE_DIRECTORY}/CMakeLists.txt)
+    # add all subdirectories of the source directory recursively
+    file(GLOB_RECURSE CMAKELISTS_FILES ${CMAKE_CURRENT_LIST_DIR}/${SOURCE_DIRECTORY}/CMakeLists.txt ${CMAKE_CURRENT_LIST_DIR}/${SOURCE_DIRECTORY}/**/CMakeLists.txt)
+
+    if (CMAKELISTS_FILES)
       message(STATUS "Source directory: '${CMAKE_CURRENT_LIST_DIR}/${SOURCE_DIRECTORY}'")
 
-      # add all subdirectories of the source directory recursively
-      file(GLOB_RECURSE CMAKELISTS_FILES ${CMAKE_CURRENT_LIST_DIR}/${SOURCE_DIRECTORY}/CMakeLists.txt ${CMAKE_CURRENT_LIST_DIR}/${SOURCE_DIRECTORY}/**/CMakeLists.txt)
       foreach (CMAKELISTS_FILE ${CMAKELISTS_FILES})
         get_filename_component(CMAKELISTS_FILE_PATH ${CMAKELISTS_FILE} DIRECTORY)
         add_subdirectory(${CMAKELISTS_FILE_PATH})

--- a/common/cpp/robocin/CMakeLists.txt
+++ b/common/cpp/robocin/CMakeLists.txt
@@ -1,1 +1,0 @@
-add_subdirectory(utility)


### PR DESCRIPTION
#28 and #38 changes CMake rules to support C++20 modules and implicit add `add_subdirectory` for all CMakeLists.txt files inside source folder. However, it add bugs in both cases, as notice at #26.

This PR fixes both behaviors and updates `common/cpp` library CMake rules.