### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![RobôCIn](https://img.shields.io/badge/🇧🇷-RobôCIn-009B3A)](https://robocin.com.br)
 [![Issues](https://img.shields.io/github/issues/robocin/ssl-core)](https://github.com/robocin/ssl-core/issues)
-[![Lint and Formatting Checker](https://github.com/robocin/ssl-core/actions/workflows/lint-and-formatting-checker.yaml/badge.svg?branch=main)](https://github.com/robocin/ssl-core/actions/workflows/lint-and-formatting-checker.yaml?query=branch%3Amain)
+[![Buf: Lint and Formatting Checker](https://github.com/robocin/ssl-core/actions/workflows/buf-lint-and-formatting-checker.yaml/badge.svg?branch=main)](https://github.com/robocin/ssl-core/actions/workflows/buf-lint-and-formatting-checker.yaml?query=branch%3Amain)
 [![Pull Requests](https://img.shields.io/github/issues-pr/robocin/ssl-core)](https://github.com/robocin/ssl-core/pulls)
 [![C++](https://img.shields.io/badge/C%2B%2B-23%2B-darkblue.svg)](https://en.cppreference.com/w/cpp/23)
 [![CMake](https://img.shields.io/badge/CMake-3.29%2B-blue.svg)](https://cmake.org/cmake/help/latest/release/3.29.html)


### PR DESCRIPTION
After #74, the `Lint and Formatting Checker` became broken, this PR aims to fix this behavior.

![image](https://github.com/robocin/ssl-core/assets/29347477/6ddab7f8-f644-485d-ad85-d1a540f419a8)