### PR TITLE
Refactor `thread_pool`

### DIFF
--- a/common/cpp/robocin/concurrency/thread_pool.cpp
+++ b/common/cpp/robocin/concurrency/thread_pool.cpp
@@ -1,12 +1,10 @@
 #include "robocin/concurrency/thread_pool.h"
 
+#include <functional>
+
 namespace robocin {
 
-/**
- * @brief Constructs a ThreadPool object with the specified number of threads.
- * @param num_threads The number of threads in the thread pool.
- */
-ThreadPool::ThreadPool(size_t num_threads) : stop_(false) {
+ThreadPool::ThreadPool(size_t num_threads) : is_stopped_{false} {
   workers_.reserve(num_threads);
 
   for (size_t i = 0; i < num_threads; ++i) {
@@ -14,82 +12,34 @@ ThreadPool::ThreadPool(size_t num_threads) : stop_(false) {
   }
 }
 
-/**
- * @brief Restarts the thread pool by initializing worker threads.
- *
- * This method restarts the thread pool by initializing the worker threads, allowing
- * the thread pool to be used for enqueuing tasks again after it has been stopped.
- *
- * @note If the thread pool is already running, calling this method has no effect.
- *       Use the stop method to stop the thread pool before calling start again.
- */
-void ThreadPool::restart() {
-  stop_ = false;
-  for (auto& worker : workers_) {
-    worker = std::thread([this] { workLoop(); });
-  }
-}
-
-/**
- * @brief Stops the thread pool and joins all worker threads.
- *
- * This method stops the thread pool and joins all worker threads. After calling this
- * method, the thread pool can no longer be used to enqueue tasks.
- */
 void ThreadPool::stop() {
   {
-    std::unique_lock<std::mutex> lock(queue_mutex_);
-    stop_ = true;
+    std::unique_lock lock(works_mutex_);
+    is_stopped_ = true;
   }
 
-  condition_.notify_all();
-
-  // Join all worker threads
-  for (std::thread& worker : workers_) {
-    if (worker.joinable()) {
-      worker.join();
-    }
-  }
+  cv_.notify_all();
 }
 
-/**
- * @brief Destroys the ThreadPool object.
- *
- * Calls the `stop` function to stop the thread pool.
- */
-ThreadPool::~ThreadPool() { this->stop(); }
+ThreadPool::~ThreadPool() { stop(); }
 
-/**
- * @brief Indicates whether the worker can execute tasks.
- *
- * It checks if the thread pool is stopped and if there are
- * tasks available to be executed.
- */
-bool ThreadPool::workAvailable() { return this->stop_ || !this->tasks_.empty(); }
-
-/**
- * @brief Worker thread loop function.
- *
- * Waits for tasks to be added to the task queue and executes them.
- */
 void ThreadPool::workLoop() {
+  std::move_only_function<void()> work;
+
   while (true) {
-    std::function<void()> task;
-
     {
-      std::unique_lock<std::mutex> lock(this->queue_mutex_);
+      std::unique_lock lock(works_mutex_);
+      cv_.wait(lock, [this]() { return !works_.empty() || is_stopped_; });
 
-      this->condition_.wait(lock, [this] { return workAvailable(); });
-
-      if (this->stop_ && this->tasks_.empty()) {
+      if (works_.empty() && is_stopped_) {
         return;
       }
 
-      task = std::move(this->tasks_.front());
-      this->tasks_.pop();
+      work = std::move(works_.front());
+      works_.pop();
     }
 
-    task();
+    work();
   }
 }
 

--- a/common/cpp/robocin/concurrency/thread_pool.h
+++ b/common/cpp/robocin/concurrency/thread_pool.h
@@ -11,80 +11,87 @@
 
 namespace robocin {
 
-class IThreadPool {
+class ThreadPool {
  public:
-  explicit IThreadPool() = default;
-  virtual ~IThreadPool() = default;
-
-  IThreadPool(const IThreadPool&) = delete;
-  IThreadPool& operator=(const IThreadPool&) = delete;
-  IThreadPool(IThreadPool&&) = delete;
-  IThreadPool& operator=(IThreadPool&&) = delete;
-
-  virtual void restart() = 0;
-  virtual void stop() = 0;
-
-  template <typename F, typename... Args>
-  auto enqueue(F&& f, Args&&... args) -> std::future<std::invoke_result_t<F, Args...>>;
-};
-
-class ThreadPool : public IThreadPool {
- public:
+  /**
+   * @brief Constructs a ThreadPool object with the specified number of threads.
+   * @param num_threads The number of threads in the thread pool.
+   */
   explicit ThreadPool(size_t num_threads);
-  ~ThreadPool() override;
+
+  /**
+   * @brief Destroys the ThreadPool object.
+   *
+   * Calls the `stop` function to stop the thread pool.
+   */
+  ~ThreadPool();
 
   ThreadPool(const ThreadPool&) = delete;
   ThreadPool& operator=(const ThreadPool&) = delete;
   ThreadPool(ThreadPool&&) = delete;
   ThreadPool& operator=(ThreadPool&&) = delete;
 
-  template <typename F, typename... Args>
-  auto enqueue(F&& f, Args&&... args) -> std::future<std::invoke_result_t<F, Args...>>;
-  void restart() override;
-  void stop() override;
+  /**
+   * @brief Enqueues a task to be executed by a thread in the pool when
+      the ThreadPool is not stopped.
+   * @tparam F Type of the function to be executed.
+   * @tparam Args Types of the arguments to be passed to the function.
+   * @param f Function to be executed.
+   * @param args Arguments to be passed to the function.
+   * @return A future representing the result of the function execution.
+   */
+  template <class F, class... Args>
+  std::future<std::invoke_result_t<F, Args...>> enqueue(F&& f, Args&&... args);
+
+  /**
+   * @brief Stops the thread pool and joins all worker threads.
+   *
+   * This method stops the thread pool and joins all worker threads. After calling this
+   * method, the thread pool can no longer be used to enqueue works.
+   */
+  void stop();
 
  private:
-  std::vector<std::thread> workers_;
-  std::queue<std::function<void()>> tasks_;
-  std::mutex queue_mutex_;
-  std::condition_variable condition_;
-  bool stop_;
-
-  bool workAvailable();
+  /**
+   * @brief Worker thread loop function.
+   *
+   * Waits for works to be added to the works queue and executes them.
+   */
   void workLoop();
+
+  std::mutex works_mutex_;
+  std::condition_variable cv_;
+  std::queue<std::move_only_function<void()>> works_;
+  std::vector<std::jthread> workers_;
+
+  bool is_stopped_;
 };
 
-/**
- * @brief Enqueues a task to be executed by a thread in the pool when
-    the ThreadPool is not stopped.
- * @tparam F Type of the function to be executed.
- * @tparam Args Types of the arguments to be passed to the function.
- * @param f Function to be executed.
- * @param args Arguments to be passed to the function.
- * @return A future representing the result of the function execution.
- */
-template <typename F, typename... Args>
-auto ThreadPool::enqueue(F&& f, Args&&... args) -> std::future<std::invoke_result_t<F, Args...>> {
+template <class F, class... Args>
+std::future<std::invoke_result_t<F, Args...>> ThreadPool::enqueue(F&& f, Args&&... args) {
   using return_type = std::invoke_result_t<F, Args...>;
 
-  auto task
-      = std::shared_ptr<std::packaged_task<return_type()>>(new std::packaged_task<return_type()>(
-          std::bind_front(std::forward<F>(f), std::forward<Args>(args)...)));
+  std::packaged_task<return_type()> task{
+      std::bind_front(std::forward<F>(f), std::forward<Args>(args)...),
+  };
 
-  auto result = task->get_future();
+  auto future_result = task.get_future();
 
   {
-    if (stop_) {
-      throw std::runtime_error("enqueue on stopped ThreadPool.");
+    std::unique_lock lock(works_mutex_);
+
+    if (is_stopped_) {
+      throw std::runtime_error("ThreadPool: enqueue on stopped thread pool.");
     }
-    std::unique_lock<std::mutex> lock(queue_mutex_);
-    tasks_.emplace([task]() { (*task)(); });
+
+    works_.emplace([work_fn = std::move(task)]() mutable { work_fn(); });
   }
 
-  condition_.notify_one();
+  cv_.notify_one();
 
-  return result;
+  return future_result;
 }
+
 } // namespace robocin
 
 #endif // ROBOCIN_UTILITY_THREAD_POOL_H

--- a/common/cpp/robocin/concurrency/thread_pool_test.cpp
+++ b/common/cpp/robocin/concurrency/thread_pool_test.cpp
@@ -1,129 +1,35 @@
 #include "robocin/concurrency/thread_pool.h"
 
-#include <cstddef>
 #include <future>
 #include <gtest/gtest.h>
 #include <stdexcept>
 
 namespace robocin {
 
-/*
- * @class ThreadPoolSpy
- * @brief A spy class for testing ThreadPool.
- *
- * This class is designed to be used in unit tests to spy on the behavior of a ThreadPool.
- * It inherits from the IThreadPool interface to provide a mock implementation with additional
- * functionality for testing purposes.
- */
-class ThreadPoolSpy : public IThreadPool {
- public:
-  explicit ThreadPoolSpy(size_t num_threads) : workers_size_(num_threads){};
-
-  void stop() override { stop_ = true; }
-  void restart() override { stop_ = false; }
-
-  template <typename F, typename... Args>
-  auto enqueue(F&& f, Args&&... args) -> std::future<std::invoke_result_t<F, Args...>> {
-    using return_type = std::invoke_result_t<F, Args...>;
-    auto task
-        = std::shared_ptr<std::packaged_task<return_type()>>(new std::packaged_task<return_type()>(
-            std::bind_front(std::forward<F>(f), std::forward<Args>(args)...)));
-    auto result = task->get_future();
-
-    {
-      if (isStopped()) {
-        throw std::runtime_error("enqueue on stopped ThreadPool.");
-      }
-      tasks_.emplace([task]() { (*task)(); });
-    }
-
-    return result;
-  }
-
-  void runEnqueuedTasks() {
-    size_t available_workers = workers_size_;
-    while (!tasks_.empty() && ((available_workers--) > 0)) {
-      std::function<void()> task;
-      task = std::move(this->tasks_.front());
-      this->tasks_.pop();
-      task();
-    }
-  }
-
-  [[nodiscard]] size_t pendentTasks() const { return tasks_.size(); }
-
-  [[nodiscard]] bool hasTasks() const { return !tasks_.empty(); }
-
-  [[nodiscard]] bool isStopped() const { return stop_; }
-
-  [[nodiscard]] bool isRunning() const { return !stop_; }
-
- private:
-  std::queue<std::function<void()>> tasks_;
-  bool stop_{};
-  size_t workers_size_;
-};
-
-TEST(ThreadPoolTest, WhenStopThreadPoolThenThreadPoolIsStopped) {
-  ThreadPoolSpy pool(/*num_threads=*/4);
-
-  pool.stop();
-
-  EXPECT_TRUE(pool.isStopped());
-}
+static constexpr int kNumThreads = 4;
 
 TEST(ThreadPoolTest, GivenStoppedThreadPoolWhenEnqueueTaskThenThrowsRuntimeError) {
-  ThreadPoolSpy pool(/*num_threads=*/4);
+  ThreadPool thread_pool(kNumThreads);
 
-  pool.stop();
+  thread_pool.stop();
 
-  EXPECT_THROW(pool.enqueue([]() {}), std::runtime_error);
-}
-
-TEST(ThreadPoolTest, WhenRestartAStoppedThreadPoolThenThreadPoolIsRestarted) {
-  ThreadPoolSpy pool(/*num_threads=*/4);
-
-  pool.stop();
-  EXPECT_TRUE(pool.isStopped());
-
-  pool.restart();
-  EXPECT_TRUE(pool.isRunning());
-}
-
-TEST(ThreadPoolTest, GivenRestartedThreadPoolWhenEnqueueTaskThenReturnsTheTaskResult) {
-  ThreadPoolSpy pool(/*num_threads=*/4);
-
-  pool.stop();
-  pool.restart();
-
-  auto future = pool.enqueue([](int a, int b) { return a + b; }, 2, 3);
-  EXPECT_EQ(pool.pendentTasks(), 1);
-
-  pool.runEnqueuedTasks();
-
-  EXPECT_EQ(future.get(), 5);
+  EXPECT_THROW(thread_pool.enqueue([]() {}), std::runtime_error);
 }
 
 TEST(ThreadPoolTest, WhenEnqueueTaskThenReturnsTheTaskResult) {
-  ThreadPoolSpy pool(/*num_threads=*/4);
+  ThreadPool thread_pool(kNumThreads);
 
-  auto future = pool.enqueue([]() { return 1; });
-  EXPECT_EQ(pool.pendentTasks(), 1);
-
-  pool.runEnqueuedTasks();
+  auto future = thread_pool.enqueue([]() { return 1; });
 
   EXPECT_EQ(future.get(), 1);
 }
 
 TEST(ThreadPoolTest, WhenEnqueueMultipleTasksThenReturnsTheTaskResults) {
-  ThreadPoolSpy pool(/*num_threads=*/4);
+  ThreadPool thread_pool(kNumThreads);
 
-  auto future1 = pool.enqueue([]() { return 1; });
-  auto future2 = pool.enqueue([]() { return 2; });
-  auto future3 = pool.enqueue([]() { return 3; });
-  EXPECT_EQ(pool.pendentTasks(), 3);
-
-  pool.runEnqueuedTasks();
+  auto future1 = thread_pool.enqueue([]() { return 1; });
+  auto future2 = thread_pool.enqueue([]() { return 2; });
+  auto future3 = thread_pool.enqueue([]() { return 3; });
 
   EXPECT_EQ(future1.get(), 1);
   EXPECT_EQ(future2.get(), 2);
@@ -131,39 +37,35 @@ TEST(ThreadPoolTest, WhenEnqueueMultipleTasksThenReturnsTheTaskResults) {
 }
 
 TEST(ThreadPoolTest, WhenEnqueueTaskWithArgumentsThenReturnsTheTaskResultForProvidedArguments) {
-  ThreadPoolSpy pool(/*num_threads=*/4);
+  ThreadPool thread_pool(kNumThreads);
 
-  auto future = pool.enqueue([](int a, int b) { return a + b; }, 2, 3);
-  EXPECT_EQ(pool.pendentTasks(), 1);
-
-  pool.runEnqueuedTasks();
+  auto future = thread_pool.enqueue([](int a, int b) { return a + b; }, 2, 3);
 
   EXPECT_EQ(future.get(), 5);
 }
 
 TEST(ThreadPoolTest, WhenEnqueueTaskThatThrowsExceptionThenThrowsSameException) {
-  ThreadPoolSpy pool(/*num_threads=*/4);
+  ThreadPool thread_pool(kNumThreads);
 
-  auto future = pool.enqueue([]() { throw std::logic_error("Test exception"); });
-  EXPECT_EQ(pool.pendentTasks(), 1);
-
-  pool.runEnqueuedTasks();
+  auto future = thread_pool.enqueue([]() { throw std::logic_error("something went wrong."); });
 
   EXPECT_THROW(future.get(), std::logic_error);
 }
 
-TEST(ThreadPoolTest, WhenEnqueueMoreTasksThanWorkersThenTasksCallingAreLimitedByWorkersSize) {
-  ThreadPoolSpy pool(/*num_threads=*/4);
+TEST(ThreadPoolTest, WhenEnqueueMoreTasksThanWorkersThenReturnsTheTaskResults) {
+  ThreadPool thread_pool(kNumThreads);
 
-  auto future1 = pool.enqueue([]() { return 1; });
-  auto future2 = pool.enqueue([]() { return 2; });
-  auto future3 = pool.enqueue([]() { return 3; });
-  auto future4 = pool.enqueue([]() { return 4; });
-  auto future5 = pool.enqueue([]() { return 5; });
-  EXPECT_EQ(pool.pendentTasks(), 5);
+  auto future1 = thread_pool.enqueue([]() { return 1; });
+  auto future2 = thread_pool.enqueue([]() { return 2; });
+  auto future3 = thread_pool.enqueue([]() { return 3; });
+  auto future4 = thread_pool.enqueue([]() { return 4; });
+  auto future5 = thread_pool.enqueue([]() { return 5; });
 
-  pool.runEnqueuedTasks();
-
-  EXPECT_TRUE(pool.hasTasks());
+  EXPECT_EQ(future1.get(), 1);
+  EXPECT_EQ(future2.get(), 2);
+  EXPECT_EQ(future3.get(), 3);
+  EXPECT_EQ(future4.get(), 4);
+  EXPECT_EQ(future5.get(), 5);
 }
+
 } // namespace robocin

--- a/experiments/thread_pool/.devcontainer/Dockerfile
+++ b/experiments/thread_pool/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM robocin/clang-cpp23-ubuntu-latest:manual-experimental-v7
+FROM robocin/ssl-core-cpp-base:latest
 
 COPY .cmake/ /tmp/.cmake/
 COPY common/ /tmp/common/

--- a/experiments/thread_pool/.devcontainer/devcontainer.json
+++ b/experiments/thread_pool/.devcontainer/devcontainer.json
@@ -1,92 +1,98 @@
-// For format details, see https://aka.ms/devcontainer.json.
 {
-    "name": "C++",
-    "build": {
-      "context": "./../../..",
-      "dockerfile": "Dockerfile"
-    },
-    "runArgs": [
-      "-e",
-      "DISPLAY=${env:DISPLAY}",
-      "--network=host"
-    ],
-    "customizations": {
-      "vscode": {
-        "extensions": [
-          // C/C++ Extension Pack
-          "ms-vscode.cpptools-extension-pack",
-          // clangd
-          "llvm-vs-code-extensions.vscode-clangd",
-          // GitLens - Git supercharged
-          "eamodio.gitlens",
-          // GitHub Copilot
-          "GitHub.copilot",
-          // Code Spell Checker
-          "streetsidesoftware.code-spell-checker",
-          // YAML
-          "redhat.vscode-yaml",
-          // Protobuf Language Support
-          "zxh404.vscode-proto3",
-          // Python
-          "ms-python.python"
-        ],
-        "settings": {
-          "files.associations": {
-            "*.cppm": "cpp",
-            "*.ixx": "cpp"
+  "name": "C++",
+  "build": {
+    "context": "./../../..",
+    "dockerfile": "Dockerfile"
+  },
+  "runArgs": [
+    "-e",
+    "DISPLAY=${env:DISPLAY}",
+    "--network=host"
+  ],
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        // Docker
+        "ms-azuretools.vscode-docker",
+        // Live Share
+        "ms-vsliveshare.vsliveshare",
+        // C/C++ Extension Pack
+        "ms-vscode.cpptools-extension-pack",
+        // clangd
+        "llvm-vs-code-extensions.vscode-clangd",
+        // Buf - Protobuf Language Support
+        "bufbuild.vscode-buf",
+        // GitLens - Git supercharged
+        "eamodio.gitlens",
+        // GitHub Copilot
+        "GitHub.copilot",
+        // Code Spell Checker
+        "streetsidesoftware.code-spell-checker",
+        // Markdown
+        "yzhang.markdown-all-in-one",
+        // YAML
+        "redhat.vscode-yaml"
+      ],
+      "settings": {
+        "files.associations": {
+          "*.cppm": "cpp",
+          "*.ixx": "cpp"
+        },
+        // C++ Settings
+        "[cpp]": {
+          "editor.insertSpaces": true,
+          "editor.tabSize": 2,
+          "editor.formatOnSave": true,
+          "editor.defaultFormatter": "llvm-vs-code-extensions.vscode-clangd"
+        },
+        // C/C++ Settings
+        "C_Cpp.intelliSenseEngine": "disabled", // disabling IntelliSense Engine to use clangd
+        // clangd Settings
+        "clangd.path": "clangd",
+        // CMake Settings
+        "cmake.buildDirectory": "${workspaceFolder}/build",
+        "cmake.cmakePath": "cmake",
+        "cmake.generator": "Ninja",
+        "cmake.options.advanced": {
+          "build": {
+            "statusBarVisibility": "visible"
           },
-          // C++ Settings
-          "[cpp]": {
-            "editor.insertSpaces": true,
-            "editor.tabSize": 2,
-            "editor.formatOnSave": true,
-            "editor.defaultFormatter": "llvm-vs-code-extensions.vscode-clangd"
+          "launch": {
+            "statusBarVisibility": "visible"
           },
-          // C/C++ Settings
-          "C_Cpp.intelliSenseEngine": "disabled", // disabling IntelliSense Engine to use clangd
-          // clangd Settings
-          "clangd.path": "clangd",
-          // CMake Settings
-          "cmake.buildDirectory": "${workspaceFolder}/build",
-          "cmake.cmakePath": "cmake",
-          "cmake.generator": "Ninja",
-          "cmake.options.advanced": {
-            "build": {
-              "statusBarVisibility": "visible"
-            },
-            "launch": {
-              "statusBarVisibility": "visible"
-            },
-            "debug": {
-              "statusBarVisibility": "visible"
-            }
-          },
-          // Code Spell Checker Settings
-          "cSpell.language": "en, pt-BR",
-          "cSpell.words": [
-            "robocin",
-            "RoboCIn",
-            "RobôCIn"
-          ],
-          // Editor Settings
-          "editor.detectIndentation": true,
-          // Files Settings
-          "files.insertFinalNewline": true,
-          // JSON Settings
-          "[json]": {
-            "editor.insertSpaces": true,
-            "editor.tabSize": 2,
-            "editor.formatOnSave": true,
-            "editor.defaultFormatter": "vscode.json-language-features"
-          },
-          // YAML Settings
-          "[yaml]": {
-            "editor.insertSpaces": true,
-            "editor.tabSize": 2,
-            "editor.formatOnSave": true,
-            "editor.defaultFormatter": "redhat.vscode-yaml"
+          "debug": {
+            "statusBarVisibility": "visible"
           }
+        },
+        // Code Spell Checker Settings
+        "cSpell.language": "en, pt-BR",
+        "cSpell.words": [
+          "robocin",
+          "RoboCIn",
+          "RobôCIn"
+        ],
+        // Editor Settings
+        "editor.detectIndentation": true,
+        // Files Settings
+        "files.insertFinalNewline": true,
+        // JSON Settings
+        "[json]": {
+          "editor.insertSpaces": true,
+          "editor.tabSize": 2,
+          "editor.formatOnSave": true,
+          "editor.defaultFormatter": "vscode.json-language-features"
+        },
+        // YAML Settings
+        "[yaml]": {
+          "editor.insertSpaces": true,
+          "editor.tabSize": 2,
+          "editor.formatOnSave": true,
+          "editor.defaultFormatter": "redhat.vscode-yaml"
+        },
+        "[markdown]": {
+          "editor.formatOnSave": true
         }
       }
     }
   }
+}

--- a/experiments/thread_pool/CMakeLists.txt
+++ b/experiments/thread_pool/CMakeLists.txt
@@ -1,6 +1,6 @@
 ########################################################################################################################
 
-cmake_minimum_required(VERSION 3.28)
+cmake_minimum_required(VERSION 3.29)
 
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/../../.cmake)
 


### PR DESCRIPTION
This PR suggest:
- Replace `std::function` by `std::move_only_function`;
- Replace `std::thread` by `std::jthread`;
- Remove `restart` method;
- Remove `spy` and test using the concrete implementation of the `ThreadPool`;
- Move documentation to header file;
- Remove the `shared_ptr` used;
- Update thread_pool experiment devcontainer;