### PR TITLE
Refactor common/cpp/network library

### DIFF
--- a/common/cpp/robocin/network/CMakeLists.txt
+++ b/common/cpp/robocin/network/CMakeLists.txt
@@ -1,8 +1,14 @@
 robocin_cpp_library(
     NAME network
-    HDRS udp_multicast_socket_receiver.h zmq_subscriber_socket.h zmq_publisher_socket.h
-    SRCS udp_multicast_socket_receiver.cpp zmq_subscriber_socket.cpp zmq_publisher_socket.cpp
+    HDRS udp_multicast_socket_receiver.h zmq_datagram.h zmq_subscriber_socket.h zmq_publisher_socket.h
+    SRCS udp_multicast_socket_receiver.cpp zmq_datagram.cpp zmq_subscriber_socket.cpp zmq_publisher_socket.cpp
     DEPS cppzmq GTest::gtest
+)
+
+robocin_cpp_test(
+  NAME zmq_datagram_test
+  SRCS zmq_datagram_test.cpp
+  DEPS network
 )
 
 robocin_cpp_test(

--- a/common/cpp/robocin/network/udp_multicast_socket_receiver.cpp
+++ b/common/cpp/robocin/network/udp_multicast_socket_receiver.cpp
@@ -21,9 +21,7 @@ UdpMulticastSocketReceiver::UdpMulticastSocketReceiver(size_t size) :
     fd_(socket(AF_INET, SOCK_DGRAM, 0)),
     size_(size) {}
 
-void UdpMulticastSocketReceiver::connect(std::string_view ip_address,
-                                         std::string_view inet_address,
-                                         int port) const {
+void UdpMulticastSocketReceiver::connect(std::string_view ip_address, int port) const {
   if (::setsockopt(fd_,
                    SOL_SOCKET,
                    SO_REUSEADDR,
@@ -35,7 +33,7 @@ void UdpMulticastSocketReceiver::connect(std::string_view ip_address,
 
   if (::ip_mreqn membership{
           .imr_multiaddr = {.s_addr = ::inet_addr(std::string{ip_address}.data())},
-          .imr_address = {.s_addr = ::inet_addr(std::string{inet_address}.data())},
+          .imr_address = {.s_addr = ::htonl(INADDR_ANY)},
       };
       ::setsockopt(fd_, IPPROTO_IP, IP_ADD_MEMBERSHIP, &membership, sizeof(membership)) == -1) {
     throw std::runtime_error("failed to set IP_ADD_MEMBERSHIP.");
@@ -43,8 +41,8 @@ void UdpMulticastSocketReceiver::connect(std::string_view ip_address,
 
   if (::sockaddr_in udp_addr{
           .sin_family = AF_INET,
-          .sin_port = htons(port),
-          .sin_addr = {.s_addr = ::inet_addr(std::string{ip_address}.data())},
+          .sin_port = ::htons(port),
+          .sin_addr = {.s_addr = INADDR_ANY},
       };
       ::bind(fd_,
              reinterpret_cast<::sockaddr*>(&udp_addr), // NOLINT(*reinterpret-cast*)

--- a/common/cpp/robocin/network/udp_multicast_socket_receiver.h
+++ b/common/cpp/robocin/network/udp_multicast_socket_receiver.h
@@ -9,8 +9,7 @@ class IUdpMulticastSocketReceiver { // NOLINT(*member-functions*)
  public:
   virtual ~IUdpMulticastSocketReceiver() = default;
 
-  virtual void connect(std::string_view ip_address, std::string_view inet_address, int port) const
-      = 0;
+  virtual void connect(std::string_view ip_address, int port) const = 0;
   [[nodiscard]] virtual std::string receive() const = 0;
   virtual void close() const = 0;
 
@@ -23,7 +22,7 @@ class UdpMulticastSocketReceiver : public IUdpMulticastSocketReceiver {
 
   explicit UdpMulticastSocketReceiver(size_t size = 1024);
 
-  void connect(std::string_view ip_address, std::string_view inet_address, int port) const override;
+  void connect(std::string_view ip_address, int port) const override;
   [[nodiscard]] std::string receive() const override;
   void close() const override;
 

--- a/common/cpp/robocin/network/zmq_datagram.cpp
+++ b/common/cpp/robocin/network/zmq_datagram.cpp
@@ -1,0 +1,15 @@
+#include "robocin/network/zmq_datagram.h"
+
+namespace robocin {
+
+ZmqDatagram::ZmqDatagram(std::string_view topic, std::string_view message) : // NOLINT(*swappable*)
+    topic_(topic),
+    message_(message) {}
+
+std::string_view ZmqDatagram::topic() const { return topic_; }
+
+std::string_view ZmqDatagram::message() const { return message_; }
+
+bool ZmqDatagram::empty() const { return topic_.empty() && message_.empty(); }
+
+} // namespace robocin

--- a/common/cpp/robocin/network/zmq_datagram.h
+++ b/common/cpp/robocin/network/zmq_datagram.h
@@ -1,0 +1,27 @@
+#ifndef ROBOCIN_NETWORK_ZMQ_DATAGRAM_H
+#define ROBOCIN_NETWORK_ZMQ_DATAGRAM_H
+
+#include <string>
+#include <string_view>
+
+namespace robocin {
+
+class ZmqDatagram {
+ public:
+  ZmqDatagram() = default;
+  ZmqDatagram(std::string_view topic, std::string_view message);
+
+  [[nodiscard]] std::string_view topic() const;
+  [[nodiscard]] std::string_view message() const;
+  [[nodiscard]] bool empty() const;
+
+  friend inline bool operator==(const ZmqDatagram& lhs, const ZmqDatagram& rhs) = default;
+
+ private:
+  std::string topic_;
+  std::string message_;
+};
+
+} // namespace robocin
+
+#endif // ROBOCIN_NETWORK_ZMQ_DATAGRAM_H

--- a/common/cpp/robocin/network/zmq_datagram_test.cpp
+++ b/common/cpp/robocin/network/zmq_datagram_test.cpp
@@ -1,0 +1,31 @@
+#include "robocin/network/zmq_datagram.h"
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include <string_view>
+
+namespace robocin {
+
+constexpr std::string_view kTopic = "topic";
+constexpr std::string_view kMessage = "message";
+
+TEST(ZmqDatagramTest, WhenZmqDatagramIsNotEmpty) {
+  ZmqDatagram datagram(kTopic, kMessage);
+
+  EXPECT_EQ(datagram.topic(), kTopic);
+  EXPECT_EQ(datagram.message(), kMessage);
+}
+
+TEST(ZmqDatagramTest, WhenEmptyReturnsTrue) {
+  ZmqDatagram datagram;
+
+  EXPECT_TRUE(datagram.empty());
+}
+
+TEST(ZmqDatagramTest, WhenEmptyReturnsFalse) {
+  ZmqDatagram datagram(kTopic, kMessage);
+
+  EXPECT_FALSE(datagram.empty());
+}
+
+} // namespace robocin

--- a/common/cpp/robocin/network/zmq_publisher_socket.h
+++ b/common/cpp/robocin/network/zmq_publisher_socket.h
@@ -7,6 +7,7 @@
 #include <string_view>
 #include <zmq.h>
 #include <zmq.hpp>
+
 namespace robocin {
 
 template <class ZmqSocket, class ZmqContext>

--- a/common/cpp/robocin/network/zmq_publisher_socket.h
+++ b/common/cpp/robocin/network/zmq_publisher_socket.h
@@ -1,28 +1,32 @@
 #ifndef ROBOCIN_NETWORK_ZMQ_PUBLISHER_SOCKET_H
 #define ROBOCIN_NETWORK_ZMQ_PUBLISHER_SOCKET_H
 
+#include "robocin/network/zmq_datagram.h"
+
 #include <gtest/gtest_prod.h>
 #include <string_view>
 #include <zmq.h>
 #include <zmq.hpp>
-
 namespace robocin {
 
 template <class ZmqSocket, class ZmqContext>
 class IZmqPublisherSocket {
  public:
+  using datagram_type = ZmqDatagram;
+
   explicit IZmqPublisherSocket(int n_threads = 1) :
       context_(n_threads),
       socket_(context_, zmq::socket_type::pub) {}
 
   void bind(std::string_view address) { socket_.bind(std::string{address}); }
 
-  void send(std::string_view topic, std::string_view message) { // NOLINT
-    if (zmq::message_t zmq_topic(topic); !socket_.send(zmq_topic, zmq::send_flags::sndmore)) {
+  void send(const datagram_type& datagram) { // NOLINT
+    if (zmq::message_t zmq_topic(datagram.topic());
+        !socket_.send(zmq_topic, zmq::send_flags::sndmore)) {
       throw std::runtime_error("failed to send topic.");
     }
 
-    if (zmq::message_t zmq_message(message);
+    if (zmq::message_t zmq_message(datagram.message());
         !socket_.send(zmq_message, zmq::send_flags::dontwait)) {
       throw std::runtime_error("failed to send message.");
     }

--- a/common/cpp/robocin/network/zmq_publisher_socket_test.cpp
+++ b/common/cpp/robocin/network/zmq_publisher_socket_test.cpp
@@ -22,7 +22,7 @@ constexpr size_t kBytesSent = 42;
 
 class MockZmqContext {
  public:
-  explicit MockZmqContext(int /*unused*/){};
+  explicit MockZmqContext(int /*unused*/) {};
 };
 
 class MockZmqSocket {
@@ -38,12 +38,14 @@ using MockZmqPublisherSocket = IZmqPublisherSocket<MockZmqSocket, MockZmqContext
 
 TEST(ZmqPublisherSocketTest, WhenBindIsSucceeded) {
   MockZmqPublisherSocket socket;
+
   EXPECT_CALL(socket.socket_, bind(Eq(kAddress)));
   socket.bind(kAddress);
 }
 
 TEST(ZmqPublisherSocketTest, WhenBindThrowsZmqError) {
   MockZmqPublisherSocket socket;
+
   EXPECT_CALL(socket.socket_, bind(Eq(kAddress))).WillOnce(Throw(zmq::error_t{}));
   EXPECT_THROW(socket.bind(kAddress), zmq::error_t);
 }
@@ -57,7 +59,7 @@ TEST(ZmqPublisherSocketTest, WhenSendIsSucceeded) {
       .WillOnce(Return(kBytesSent));
   EXPECT_CALL(socket.socket_, send(Eq(std::cref(zmq_message)), Eq(zmq::send_flags::dontwait)))
       .WillOnce(Return(kBytesSent));
-  EXPECT_NO_THROW(socket.send(kDefaultTopic, kDefaultMessage));
+  EXPECT_NO_THROW(socket.send({kDefaultTopic, kDefaultMessage}));
 }
 
 TEST(ZmqPublisherSocketTest, WhenSendThrowsZmqErrorForTopic) {
@@ -66,7 +68,7 @@ TEST(ZmqPublisherSocketTest, WhenSendThrowsZmqErrorForTopic) {
 
   EXPECT_CALL(socket.socket_, send(Eq(std::cref(zmq_topic)), Eq(zmq::send_flags::sndmore)))
       .WillOnce(Throw(zmq::error_t{}));
-  EXPECT_THROW(socket.send(kDefaultTopic, kDefaultMessage), zmq::error_t);
+  EXPECT_THROW(socket.send({kDefaultTopic, kDefaultMessage}), zmq::error_t);
 }
 
 TEST(ZmqPublisherSocketTest, WhenSendThrowsZmqErrorForMessage) {
@@ -78,7 +80,7 @@ TEST(ZmqPublisherSocketTest, WhenSendThrowsZmqErrorForMessage) {
       .WillOnce(Return(kBytesSent));
   EXPECT_CALL(socket.socket_, send(Eq(std::cref(zmq_message)), Eq(zmq::send_flags::dontwait)))
       .WillOnce(Throw(zmq::error_t{}));
-  EXPECT_THROW(socket.send(kDefaultTopic, kDefaultMessage), zmq::error_t);
+  EXPECT_THROW(socket.send({kDefaultTopic, kDefaultMessage}), zmq::error_t);
 }
 
 TEST(ZmqPublisherSocketTest, WhenSendThrowsRuntimeErrorForTopic) {
@@ -87,7 +89,7 @@ TEST(ZmqPublisherSocketTest, WhenSendThrowsRuntimeErrorForTopic) {
 
   EXPECT_CALL(socket.socket_, send(Eq(std::cref(zmq_topic)), Eq(zmq::send_flags::sndmore)))
       .WillOnce(Return(std::nullopt));
-  ASSERT_THROW(socket.send(kDefaultTopic, kDefaultMessage), std::runtime_error);
+  ASSERT_THROW(socket.send({kDefaultTopic, kDefaultMessage}), std::runtime_error);
 }
 
 TEST(ZmqPublisherSocketTest, WhenSendThrowsRuntimeErrorForMessage) {
@@ -99,7 +101,7 @@ TEST(ZmqPublisherSocketTest, WhenSendThrowsRuntimeErrorForMessage) {
       .WillOnce(Return(kBytesSent));
   EXPECT_CALL(socket.socket_, send(Eq(std::cref(zmq_message)), Eq(zmq::send_flags::dontwait)))
       .WillOnce(Return(std::nullopt));
-  ASSERT_THROW(socket.send(kDefaultTopic, kDefaultMessage), std::runtime_error);
+  ASSERT_THROW(socket.send({kDefaultTopic, kDefaultMessage}), std::runtime_error);
 }
 
 TEST(ZmqPublisherSocketTest, WhenCloseIsSucceeded) {

--- a/common/cpp/robocin/network/zmq_subscriber_socket.h
+++ b/common/cpp/robocin/network/zmq_subscriber_socket.h
@@ -1,6 +1,8 @@
 #ifndef ROBOCIN_NETWORK_ZMQ_SUBSCRIBER_SOCKET_H
 #define ROBOCIN_NETWORK_ZMQ_SUBSCRIBER_SOCKET_H
 
+#include "robocin/network/zmq_datagram.h"
+
 #include <gtest/gtest_prod.h>
 #include <ranges>
 #include <string>
@@ -10,17 +12,10 @@
 
 namespace robocin {
 
-struct ZmqDatagram {
-  std::string topic;
-  std::string message;
-
-  friend inline bool operator==(const ZmqDatagram& lhs, const ZmqDatagram& rhs) = default;
-};
-
 template <class ZmqContext, class ZmqSocket>
 class IZmqSubscriberSocket {
  public:
-  using receive_type = ZmqDatagram;
+  using datagram_type = ZmqDatagram;
 
   explicit IZmqSubscriberSocket(int n_threads = 1) :
       context_(n_threads),
@@ -34,10 +29,10 @@ class IZmqSubscriberSocket {
     }
   }
 
-  receive_type receive() {
+  datagram_type receive() {
     if (zmq::message_t zmq_topic; socket_.recv(zmq_topic, zmq::recv_flags::dontwait)) {
       if (zmq::message_t zmq_message; socket_.recv(zmq_message, zmq::recv_flags::dontwait)) {
-        return {.topic = zmq_topic.to_string(), .message = zmq_message.to_string()};
+        return {zmq_topic.to_string(), zmq_message.to_string()};
       }
     }
 

--- a/common/cpp/robocin/network/zmq_subscriber_socket_test.cpp
+++ b/common/cpp/robocin/network/zmq_subscriber_socket_test.cpp
@@ -118,7 +118,7 @@ TEST(ZmqSubscriberSocketTest, WhenReceiveTopicIsNullopt) {
   MockZmqSubscriberSocket socket;
 
   EXPECT_CALL(socket.socket_, recv(_, zmq::recv_flags::dontwait)).WillOnce(Return(std::nullopt));
-  ASSERT_EQ(socket.receive(), ZmqDatagram{});
+  ASSERT_TRUE(socket.receive().empty());
 }
 
 TEST(ZmqSubscriberSocketTest, WhenReceiveMessageIsNullopt) {
@@ -127,7 +127,7 @@ TEST(ZmqSubscriberSocketTest, WhenReceiveMessageIsNullopt) {
   EXPECT_CALL(socket.socket_, recv(_, zmq::recv_flags::dontwait))
       .WillOnce(RecvMockFunctor(kDefaultTopic))
       .WillOnce(Return(std::nullopt));
-  ASSERT_EQ(socket.receive(), ZmqDatagram{});
+  ASSERT_TRUE(socket.receive().empty());
 }
 
 TEST(ZmqSubscriberSocketTest, WhenFileDescriptionGetterIsSucceeded) {


### PR DESCRIPTION
This PR contains a refactor with the following changes:
- Adds a new class called ZmqDatagram to represent the data send and received by ZMQ sockets. 
- Adds unit tests for ZmqDatagram class.
- Removes INET dependency from UDP multicast receiver.

Closes #81.