### PR TITLE
Update internal protocols breaking compatibility

### DIFF
--- a/protocols/protocols/common/game_event.proto
+++ b/protocols/protocols/common/game_event.proto
@@ -9,50 +9,51 @@ import "protocols/common/robot_id.proto";
 import "protocols/common/team.proto";
 
 message GameEvent {
-  google.protobuf.Timestamp timestamp = 1;
+  repeated string sources = 1;
+  google.protobuf.Timestamp timestamp = 2;
 
   oneof event {
-    BallLeftField ball_left_field_touch_line = 2;
-    BallLeftField ball_left_field_goal_line = 3;
-    BallLeftFieldBoundary ball_left_field_boundary = 4;
-    AimlessKick aimless_kick = 5;
+    BallLeftField ball_left_field_touch_line = 3;
+    BallLeftField ball_left_field_goal_line = 4;
+    BallLeftFieldBoundary ball_left_field_boundary = 5;
+    AimlessKick aimless_kick = 6;
 
-    GoalkeeperHeldBall goalkeeper_held_ball = 6;
-    RobotTooCloseToDefenseArea robot_too_close_to_defense_area = 7;
-    RobotInDefenseArea robot_in_defense_area = 8;
-    RobotPushedRobot robot_pushed_robot = 9;
-    RobotHeldBallDeliberately robot_held_ball_deliberately = 10;
-    RobotDribbledBallTooFar robot_dribbled_ball_too_far = 11;
-    RobotTippedOver robot_tipped_over = 12;
-    RobotTouchedBallInDefenseArea robot_touched_ball_in_defense_area = 13;
-    RobotKickedBallTooFast robot_kicked_ball_too_fast = 14;
-    RobotCrashUnique robot_crash_unique = 15;
-    RobotCrashDrawn robot_crash_drawn = 16;
-    RobotTooFastInStop robot_too_fast_in_stop = 17;
-    RobotTooCloseToKickPoint robot_too_close_to_kick_point = 18;
-    RobotInterferedBallPlacement robot_interfered_ball_placement = 19;
-    RobotDoubleTouchedBall robot_double_touched_ball = 20;
+    GoalkeeperHeldBall goalkeeper_held_ball = 7;
+    RobotTooCloseToDefenseArea robot_too_close_to_defense_area = 8;
+    RobotInDefenseArea robot_in_defense_area = 9;
+    RobotPushedRobot robot_pushed_robot = 10;
+    RobotHeldBallDeliberately robot_held_ball_deliberately = 11;
+    RobotDribbledBallTooFar robot_dribbled_ball_too_far = 12;
+    RobotTippedOver robot_tipped_over = 13;
+    RobotTouchedBallInDefenseArea robot_touched_ball_in_defense_area = 14;
+    RobotKickedBallTooFast robot_kicked_ball_too_fast = 15;
+    RobotCrashUnique robot_crash_unique = 16;
+    RobotCrashDrawn robot_crash_drawn = 17;
+    RobotTooFastInStop robot_too_fast_in_stop = 18;
+    RobotTooCloseToKickPoint robot_too_close_to_kick_point = 19;
+    RobotInterferedBallPlacement robot_interfered_ball_placement = 20;
+    RobotDoubleTouchedBall robot_double_touched_ball = 21;
 
-    NoProgressInGame no_progress_in_game = 21;
-    MultipleCards multiple_cards = 22;
-    MultipleFouls multiple_fouls = 23;
-    TooManyRobots too_many_robots = 24;
+    NoProgressInGame no_progress_in_game = 22;
+    MultipleCards multiple_cards = 23;
+    MultipleFouls multiple_fouls = 24;
+    TooManyRobots too_many_robots = 25;
 
-    BallPlacementSucceeded ball_placement_succeeded = 25;
-    BallPlacementFailed ball_placement_failed = 26;
+    BallPlacementSucceeded ball_placement_succeeded = 26;
+    BallPlacementFailed ball_placement_failed = 27;
 
-    PenaltyKickFailed penalty_kick_failed = 27;
+    PenaltyKickFailed penalty_kick_failed = 28;
 
-    Goal possible_goal = 28;
-    Goal goal = 29;
-    Goal invalid_goal = 30;
+    Goal possible_goal = 29;
+    Goal goal = 30;
+    Goal invalid_goal = 31;
 
-    RobotSubstitution robot_substitution = 31;
-    ChallengeFlag challenge_flag = 32;
-    EmergencyStop emergency_stop = 33;
+    RobotSubstitution robot_substitution = 32;
+    ChallengeFlag challenge_flag = 33;
+    EmergencyStop emergency_stop = 34;
 
-    UnsportingBehaviorMinor unsporting_behavior_minor = 34;
-    UnsportingBehaviorMajor unsporting_behavior_major = 35;
+    UnsportingBehaviorMinor unsporting_behavior_minor = 35;
+    UnsportingBehaviorMajor unsporting_behavior_major = 36;
   }
 
   message BallLeftField {

--- a/protocols/protocols/perception/detection.proto
+++ b/protocols/protocols/perception/detection.proto
@@ -26,8 +26,8 @@ message Detection {
   uint64 serial_id = 1;
   // The unix timestamp of the detection creation.
   google.protobuf.Timestamp created_at = 2;
-  // The expected rate of detections generated.
-  uint32 frame_rate = 3;
+  // The expected rate of detections generated (in seconds).
+  uint32 framerate = 3;
 
   // The list of detected balls, in order of confidence.
   repeated Ball balls = 4;

--- a/protocols/protocols/perception/detection.proto
+++ b/protocols/protocols/perception/detection.proto
@@ -26,7 +26,7 @@ message Detection {
   uint64 serial_id = 1;
   // The unix timestamp of the detection creation.
   google.protobuf.Timestamp created_at = 2;
-  // The expected rate of detections generated (in seconds).
+  // The expected rate of detections generated (in frames per second).
   uint32 framerate = 3;
 
   // The list of detected balls, in order of confidence.

--- a/protocols/protocols/playback/detection.proto
+++ b/protocols/protocols/playback/detection.proto
@@ -9,7 +9,7 @@ import "protocols/common/robot_id.proto";
 message Detection {
   uint64 serial_id = 1;
   google.protobuf.Timestamp created_at = 2;
-  uint32 expected_frame_rate = 3;
+  uint32 expected_framerate = 3;
 
   repeated Ball balls = 4;
   repeated Robot robots = 5;

--- a/protocols/protocols/referee/game_status.proto
+++ b/protocols/protocols/referee/game_status.proto
@@ -18,18 +18,17 @@ message GameStatus {
 
   Team home_team = 5;
   Team away_team = 6;
-  bool is_home_team_on_positive_half = 7;
 
-  common.GameStage game_stage = 8;
-  optional google.protobuf.Duration game_stage_time_left = 9;
+  common.GameStage game_stage = 7;
+  optional google.protobuf.Duration game_stage_time_left = 8;
 
-  uint64 total_commands_issued = 10;
-  google.protobuf.Timestamp command_issued_timestamp = 11;
-  common.GameCommand command = 12;
-  common.GameCommand next_command = 13;
+  uint64 total_commands_issued = 9;
+  google.protobuf.Timestamp command_issued_timestamp = 10;
+  common.GameCommand command = 11;
+  common.GameCommand next_command = 12;
 
-  repeated common.GameEvent game_events = 14;
-  repeated GameEventsProposal game_events_proposals = 15;
+  repeated common.GameEvent game_events = 13;
+  repeated GameEventsProposal game_events_proposals = 14;
 
   message Team {
     string name = 1;


### PR DESCRIPTION
During the development of #122, some errors were noticed in the definition of the protocols. Given the current stage of development, this breakdown is still valid:

- Rename frame_rate to framerate (typo);
- Remove is_home_team_on_positive_half (not used);
- Add sources in GameEvent (forgotten field);