### PR TITLE
Add go mod tidy to fix error during build

### DIFF
--- a/gateway/gateway-augusto/Makefile
+++ b/gateway/gateway-augusto/Makefile
@@ -9,4 +9,5 @@ build-linux: # TODO(joseviccruz): CGO_ENABLED=0, i.e., static linking zmq.
 
 setup:
 	@bash ../../common/golang/scripts/compile_proto.sh
+	@go mod tidy
 	@go mod download

--- a/metrics-ms/metrics-sherlock/Makefile
+++ b/metrics-ms/metrics-sherlock/Makefile
@@ -9,4 +9,5 @@ build-linux:
 
 setup:
 	@bash ../../common/golang/scripts/compile_proto.sh
+	@go mod tidy
 	@go mod download

--- a/playback-ms/playback-caze/Makefile
+++ b/playback-ms/playback-caze/Makefile
@@ -9,4 +9,5 @@ build-linux:
 
 setup:
 	@bash ../../common/golang/scripts/compile_proto.sh
+	@go mod tidy
 	@go mod download

--- a/player-bff/player-sonson/Makefile
+++ b/player-bff/player-sonson/Makefile
@@ -9,4 +9,5 @@ build-linux:
 
 setup:
 	@bash ../../common/golang/scripts/compile_proto.sh
+	@go mod tidy 
 	@go mod download


### PR DESCRIPTION
This PR adds the command `@go mod tidy` to the microservices' Makefile in order to fix a build error when running docker compose.