### PR TITLE
Fix dev docker compose

### DIFF
--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -77,7 +77,6 @@ services:
 
   perception-ms:
     container_name: perception-ms
-    #    image: robocin/perception-brutus:manual-c7208b
     build:
       context: .
       dockerfile: perception-ms/perception-brutus/perception-brutus.Dockerfile
@@ -89,9 +88,6 @@ services:
   referee-ms:
     container_name: referee-ms
     image: robocin/referee-daronco:manual-419128
-    #    build:
-    #      context: .
-    #      dockerfile: referee-ms/referee-daronco/referee-daronco.Dockerfile
     volumes:
       - .ssl-core:/tmp/.ssl-core
     depends_on:

--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -64,6 +64,7 @@ services:
       dockerfile: gateway/gateway-augusto/gateway-augusto.Dockerfile
     environment:
       - VISION_PORT=10020
+      - GC_PORT=10003
     volumes:
       - .ssl-core:/tmp/.ssl-core
     ports:
@@ -127,7 +128,7 @@ services:
         - SOURCE_DIRECTORY=player-mfe
     command: ["-g", "daemon off;"]
     ports:
-      - 3031:80
+      - 3031:3031
     depends_on:
       - player-bff
 
@@ -139,7 +140,7 @@ services:
         - SOURCE_DIRECTORY=viewer-mfe
     command: ["-g", "daemon off;"]
     ports:
-      - 3032:80
+      - 3032:3032
 
   app-shell:
     build:
@@ -149,7 +150,7 @@ services:
         - SOURCE_DIRECTORY=app-shell
     command: ["-g", "daemon off;"]
     ports:
-      - 3030:80
+      - 3030:3030
 
   metrics-ms:
     container_name: metrics-ms

--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -17,6 +17,9 @@ services:
       - "-a"
       - "-visionAddress"
       - "224.5.23.2:10020"
+      - "-refereeAddress"
+      - "224.5.23.1:11003"
+
     logging:
       driver: none
     depends_on:
@@ -74,7 +77,7 @@ services:
 
   perception-ms:
     container_name: perception-ms
-#    image: robocin/perception-brutus:manual-c7208b
+    #    image: robocin/perception-brutus:manual-c7208b
     build:
       context: .
       dockerfile: perception-ms/perception-brutus/perception-brutus.Dockerfile
@@ -86,9 +89,9 @@ services:
   referee-ms:
     container_name: referee-ms
     image: robocin/referee-daronco:manual-419128
-#    build:
-#      context: .
-#      dockerfile: referee-ms/referee-daronco/referee-daronco.Dockerfile
+    #    build:
+    #      context: .
+    #      dockerfile: referee-ms/referee-daronco/referee-daronco.Dockerfile
     volumes:
       - .ssl-core:/tmp/.ssl-core
     depends_on:
@@ -126,7 +129,7 @@ services:
       dockerfile: player-mfe/Dockerfile
       args:
         - SOURCE_DIRECTORY=player-mfe
-    command: ["-g", "daemon off;"]
+    command: [ "-g", "daemon off;" ]
     ports:
       - 3031:3031
     depends_on:
@@ -138,7 +141,7 @@ services:
       dockerfile: viewer-mfe/Dockerfile
       args:
         - SOURCE_DIRECTORY=viewer-mfe
-    command: ["-g", "daemon off;"]
+    command: [ "-g", "daemon off;" ]
     ports:
       - 3032:3032
 
@@ -148,7 +151,7 @@ services:
       dockerfile: app-shell/Dockerfile
       args:
         - SOURCE_DIRECTORY=app-shell
-    command: ["-g", "daemon off;"]
+    command: [ "-g", "daemon off;" ]
     ports:
       - 3030:3030
 

--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -67,7 +67,7 @@ services:
       dockerfile: gateway/gateway-augusto/gateway-augusto.Dockerfile
     environment:
       - VISION_PORT=10020
-      - GC_PORT=10003
+      - GC_PORT=11003
     volumes:
       - .ssl-core:/tmp/.ssl-core
     ports:

--- a/gateway/gateway-augusto/Makefile
+++ b/gateway/gateway-augusto/Makefile
@@ -9,4 +9,5 @@ build-linux: # TODO(joseviccruz): CGO_ENABLED=0, i.e., static linking zmq.
 
 setup:
 	@bash ../../common/golang/scripts/compile_proto.sh
+	@go mod tidy
 	@go mod download

--- a/metrics-ms/metrics-sherlock/Makefile
+++ b/metrics-ms/metrics-sherlock/Makefile
@@ -9,4 +9,5 @@ build-linux:
 
 setup:
 	@bash ../../common/golang/scripts/compile_proto.sh
+	@go mod tidy
 	@go mod download

--- a/playback-ms/playback-caze/Makefile
+++ b/playback-ms/playback-caze/Makefile
@@ -9,4 +9,5 @@ build-linux:
 
 setup:
 	@bash ../../common/golang/scripts/compile_proto.sh
+	@go mod tidy
 	@go mod download

--- a/playback-ms/playback-caze/playback-caze.Dockerfile
+++ b/playback-ms/playback-caze/playback-caze.Dockerfile
@@ -12,7 +12,7 @@ RUN make setup
 RUN make build-linux
 
 RUN mkdir /prod && \
-    ldd bin/playback-ms | awk 'NF == 4 {print $3}; NF == 2 {print $1}' | grep '^/' | xargs -I {} cp --parents {} /prod
+    ldd bin/playback | awk 'NF == 4 {print $3}; NF == 2 {print $1}' | grep '^/' | xargs -I {} cp --parents {} /prod
 
 FROM gcr.io/distroless/static-debian12 AS prod
 

--- a/player-bff/player-sonson/Makefile
+++ b/player-bff/player-sonson/Makefile
@@ -9,4 +9,5 @@ build-linux:
 
 setup:
 	@bash ../../common/golang/scripts/compile_proto.sh
+	@go mod tidy 
 	@go mod download


### PR DESCRIPTION
This pull request fixes `docker-compose.dev.yaml` as it was not able to sucessfully execute `playback-ms` and `autoref`.

- Adds `@go mod tidy` to golang microservices due to building errors in some scenarios.
- playback-ms was not executing because `playback-caze.Dockerfile` was expecting a binary named `playback-ms` instead of `playback`, which was incorrect.
- `autoref` was not able to establish a connection with `game-controller` because it was trying to listen in the wrong port.

Both of these issues were solved.