### PR TITLE
Add navigation devcontainer

### DIFF
--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -194,5 +194,13 @@ services:
     depends_on:
       - metrics-db
 
+  navigation-ms:
+    container_name: navigation-ms
+    build:
+      context: .
+      dockerfile: navigation-ms/navigation-luffy/navigation-luffy.Dockerfile
+    volumes:
+      - .ssl-core:/tmp/.ssl-core
+
 volumes:
   .ssl-core:

--- a/navigation-ms/navigation-luffy/.devcontainer/devcontainer.json
+++ b/navigation-ms/navigation-luffy/.devcontainer/devcontainer.json
@@ -1,8 +1,8 @@
 {
-    "name": "C++: Navigation Jaiminho",
+    "name": "C++: Navigation Luffy",
     "build": {
         "context": "./../../..",
-        "dockerfile": "./../navigation-jaiminho.Dockerfile",
+        "dockerfile": "./../navigation-luffy.Dockerfile",
         "target": "devcontainer"
     },
     "initializeCommand": "mkdir -p /tmp/.ssl-core",

--- a/navigation-ms/navigation-luffy/.devcontainer/devcontainer.json
+++ b/navigation-ms/navigation-luffy/.devcontainer/devcontainer.json
@@ -1,0 +1,116 @@
+{
+    "name": "C++: Navigation Jaiminho",
+    "build": {
+        "context": "./../../..",
+        "dockerfile": "./../navigation-jaiminho.Dockerfile",
+        "target": "devcontainer"
+    },
+    "initializeCommand": "mkdir -p /tmp/.ssl-core",
+    "mounts": [
+        "source=/tmp/.ssl-core/,target=/tmp/.ssl-core/,type=bind,consistency=cached"
+    ],
+    "runArgs": [
+        "-e",
+        "DISPLAY=${env:DISPLAY}",
+        "--network=host"
+    ],
+    "customizations": {
+        "vscode": {
+            "extensions": [
+                // Docker
+                "ms-azuretools.vscode-docker",
+                // Live Share
+                "ms-vsliveshare.vsliveshare",
+                // C/C++ Extension Pack
+                "ms-vscode.cpptools-extension-pack",
+                // clangd
+                "llvm-vs-code-extensions.vscode-clangd",
+                // Buf - Protobuf Language Support
+                "bufbuild.vscode-buf",
+                // GitLens - Git supercharged
+                "eamodio.gitlens",
+                // GitHub Copilot
+                "GitHub.copilot",
+                // Code Spell Checker
+                "streetsidesoftware.code-spell-checker",
+                // Markdown
+                "yzhang.markdown-all-in-one",
+                // YAML
+                "redhat.vscode-yaml"
+            ],
+            "settings": {
+                "files.associations": {
+                    "*.cppm": "cpp",
+                    "*.ixx": "cpp"
+                },
+                // C++ Settings
+                "[cpp]": {
+                    "editor.insertSpaces": true,
+                    "editor.tabSize": 4,
+                    "editor.formatOnSave": true,
+                    "editor.defaultFormatter": "llvm-vs-code-extensions.vscode-clangd"
+                },
+                // C/C++ Settings
+                "C_Cpp.intelliSenseEngine": "disabled", // disabling IntelliSense Engine to use clangd
+                // clangd Settings
+                "clangd.path": "clangd",
+                "clangd.checkUpdates": false,
+                // CMake Settings
+                "cmake.buildDirectory": "${workspaceFolder}/build",
+                "cmake.cmakePath": "cmake",
+                "cmake.generator": "Ninja",
+                "cmake.options.advanced": {
+                    "kit": {
+                        "statusBarVisibility": "visible"
+                    },
+                    "launchTarget": {
+                        "statusBarVisibility": "visible"
+                    },
+                    "launch": {
+                        "statusBarVisibility": "visible"
+                    },
+                    "debug": {
+                        "statusBarVisibility": "visible"
+                    },
+                    "variant": {
+                        "statusBarVisibility": "visible"
+                    },
+                    "build": {
+                        "statusBarVisibility": "visible"
+                    },
+                    "buildTarget": {
+                        "statusBarVisibility": "visible"
+                    }
+                },
+                // Code Spell Checker Settings
+                "cSpell.language": "en, pt-BR",
+                "cSpell.words": [
+                    "robocin",
+                    "RoboCIn",
+                    "RobôCIn"
+                ],
+                // Editor Settings
+                "editor.detectIndentation": true,
+                // Files Settings
+                "files.insertFinalNewline": true,
+                // JSON Settings
+                "[json]": {
+                    "editor.insertSpaces": true,
+                    "editor.tabSize": 2,
+                    "editor.formatOnSave": true,
+                    "editor.defaultFormatter": "vscode.json-language-features"
+                },
+                // YAML Settings
+                "[yaml]": {
+                    "editor.insertSpaces": true,
+                    "editor.tabSize": 2,
+                    "editor.formatOnSave": true,
+                    "editor.defaultFormatter": "redhat.vscode-yaml"
+                },
+                "[markdown]": {
+                    "editor.formatOnSave": true
+                }
+            }
+        }
+    }
+}

--- a/navigation-ms/navigation-luffy/CMakeLists.txt
+++ b/navigation-ms/navigation-luffy/CMakeLists.txt
@@ -1,0 +1,23 @@
+########################################################################################################################
+
+cmake_minimum_required(VERSION 3.29)
+
+list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/../../.cmake)
+
+include(project)
+
+project(navigation LANGUAGES CXX)
+
+########################################################################################################################
+
+find_package(common CONFIG REQUIRED)
+message(STATUS "Using common: '${common_DIR}'")
+
+find_package(protocols CONFIG REQUIRED)
+message(STATUS "Using protocols: '${protocols_DIR}'")
+
+########################################################################################################################
+
+robocin_cpp_project_setup(STANDARD 23)
+
+########################################################################################################################

--- a/navigation-ms/navigation-luffy/navigation-luffy.Dockerfile
+++ b/navigation-ms/navigation-luffy/navigation-luffy.Dockerfile
@@ -1,0 +1,37 @@
+FROM robocin/ssl-core-cpp-base:latest AS devcontainer
+
+COPY .cmake/ /tmp/.cmake/
+COPY common/ /tmp/common/
+COPY protocols/ /tmp/protocols/
+
+RUN set -x && \
+    pushd /tmp/common/cpp && rm -rf build && \
+    cmake -B build -S . -G "Ninja" -DCMAKE_CXX_COMPILER=clang++ && \
+    cmake --build build && cmake --install build && \
+    popd && \
+    \
+    pushd /tmp/protocols && rm -rf build && \
+    cmake -B build -S . -G "Ninja" -DCMAKE_CXX_COMPILER=clang++ && \
+    cmake --build build && cmake --install build && \
+    popd && \
+    \
+    rm -rf /tmp/.cmake/ /tmp/common/ /tmp/protocols/ && \
+    : # last line
+
+FROM devcontainer AS build
+
+COPY . /
+
+WORKDIR /navigation-ms/navigation-luffy
+
+RUN set -x && \
+    rm -rf build bin && \
+    cmake -B build -S . -G "Ninja" -DCMAKE_CXX_COMPILER=clang++ && \
+    cmake --build build && \
+    : # last line
+
+FROM scratch AS prod
+
+COPY --from=build /navigation-ms/navigation-luffy/bin/navigation_main /navigation_main
+
+ENTRYPOINT [ "./navigation_main" ]

--- a/navigation-ms/navigation-luffy/navigation-luffy.code-workspace
+++ b/navigation-ms/navigation-luffy/navigation-luffy.code-workspace
@@ -1,0 +1,25 @@
+{
+    "folders": [
+        {
+            "path": ".devcontainer"
+        },
+        {
+            "path": "../../.cmake"
+        },
+        {
+            "path": "."
+        },
+        {
+            "path": "../../common/cpp"
+        },
+        {
+            "path": "../../protocols"
+        }
+    ],
+    "settings": {
+        "files.exclude": {
+            // only the top-level .devcontainer/ should be displayed
+            "**/**/.devcontainer": true,
+        }
+    }
+}

--- a/navigation-ms/navigation-luffy/navigation/CMakeLists.txt
+++ b/navigation-ms/navigation-luffy/navigation/CMakeLists.txt
@@ -1,0 +1,4 @@
+robocin_cpp_executable(
+  NAME navigation_main
+  SRCS navigation_main.cpp
+)

--- a/navigation-ms/navigation-luffy/navigation/navigation_main.cpp
+++ b/navigation-ms/navigation-luffy/navigation/navigation_main.cpp
@@ -1,0 +1,7 @@
+#include <print>
+
+int main() {
+  std::println("navigation-luffy is runnning!");
+
+  return 0;
+}


### PR DESCRIPTION
Adds required configuration files to create a `C++` devcontainer and respective service on `docker compose`. Also adds a simple `C++` implementation to be `navigation-luffy` entrypoint.
