### PR TITLE
Enable game controller view from .dev compose

### DIFF
--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -40,6 +40,7 @@ services:
     restart: unless-stopped
     ports:
       - 8081/tcp
+      - 8081:8081
     logging:
       driver: none
     depends_on:


### PR DESCRIPTION
It was not possible to access game controller UI from the docker compose because its port was not being forwarded from the container. This PRs solves this issue.

To see game controller UI, use `localhost:8081`.