### PR TITLE
Refactor robot_info message

### DIFF
--- a/protocols/protocols/communication/robot_info.proto
+++ b/protocols/protocols/communication/robot_info.proto
@@ -10,7 +10,7 @@ import "protocols/common/robot_velocity.proto";
 import "protocols/common/robot_kick.proto";
 import "protocols/common/robot_dribbler.proto";
 
-message RobotComm {
+message RobotInfo {
     oneof type {
         Command command = 1;
         common.Feedback feedback = 2;


### PR DESCRIPTION
This pull request refactors `robot_info` message, renaming the message proto from `RobotComm` to `RobotInfo`.