### PR TITLE
Fix optional uint32 number

### DIFF
--- a/protocols/protocols/common/robot_id.proto
+++ b/protocols/protocols/common/robot_id.proto
@@ -14,5 +14,5 @@ message RobotId {
   // The color of the robot.
   optional Color color = 1;
   // The number of the robot.
-  uint32 number = 2;
+  optional uint32 number = 2;
 }


### PR DESCRIPTION
Previously, when sending `robot_id.number = 0`, no information would be serialized because this is the default value of uint32 type sent in the message.

Using the field as `optional` adds explicit presence, thus sending the value despite being the default value.

For reference see [protobuf documentation](https://protobuf.dev/programming-guides/field_presence/#how-to-enable-explicit-presence-in-proto3).