### PR TITLE
Add proto convertible interface

### DIFF
--- a/common/cpp/robocin/utility/CMakeLists.txt
+++ b/common/cpp/robocin/utility/CMakeLists.txt
@@ -27,10 +27,12 @@ robocin_cpp_library(
        concepts.h
        fuzzy_compare.h
        singleton.h
+       iproto_convertible.h
   SRCS type_traits.cpp
        concepts.cpp
        fuzzy_compare.cpp
        singleton.cpp
+       iproto_convertible.cpp
   CONFIGS epsilon.h.in
 )
 

--- a/common/cpp/robocin/utility/iproto_convertible.cpp
+++ b/common/cpp/robocin/utility/iproto_convertible.cpp
@@ -1,0 +1,1 @@
+#include "robocin/utility/iproto_convertible.h"

--- a/common/cpp/robocin/utility/iproto_convertible.h
+++ b/common/cpp/robocin/utility/iproto_convertible.h
@@ -1,0 +1,24 @@
+#ifndef ROBOCIN_UTILITY_IPROTO_CONVERTIBLE
+#define ROBOCIN_UTILITY_IPROTO_CONVERTIBLE
+
+namespace robocin {
+
+template <class T>
+class IProtoConvertible {
+ public:
+  IProtoConvertible() = default;
+
+  IProtoConvertible(const IProtoConvertible&) = delete;
+  IProtoConvertible& operator=(const IProtoConvertible&) = delete;
+  IProtoConvertible(IProtoConvertible&&) noexcept = default;
+  IProtoConvertible& operator=(IProtoConvertible&&) noexcept = default;
+
+  virtual ~IProtoConvertible() = default;
+  
+  virtual T toProto() const = 0;
+  virtual void fromProto(T proto) = 0;
+};
+
+} // namespace robocin
+
+#endif // ROBOCIN_UTILITY_IPROTO_CONVERTIBLE


### PR DESCRIPTION
This PR adds an interface to be used across core. Its use is intended to create data classes owned by each service that encapsulates proto generated classes manipulation. 

These classes should be responsible for:
1. Hold data that can be translated 1:1 to `.proto` definitions. 
2. Transform object into `.proto` generated classes
3. Feed object from `.proto` generated classes

This request aids development as it encapsulates and abstracts proto manipulation in amidst domain programming for each service, which benefits developer quality of life.