### PR TITLE
Add initial decision structure

### DIFF
--- a/decision-ms/decision-guardiola/decision/processing/coach/CMakeLists.txt
+++ b/decision-ms/decision-guardiola/decision/processing/coach/CMakeLists.txt
@@ -1,5 +1,7 @@
 robocin_cpp_library(
   NAME coach
   HDRS icoach.h
+       tactical_plan/tactical_plan.h
   SRCS icoach.cpp
+       tactical_plan/tactical_plan.cpp
 )

--- a/decision-ms/decision-guardiola/decision/processing/coach/CMakeLists.txt
+++ b/decision-ms/decision-guardiola/decision/processing/coach/CMakeLists.txt
@@ -1,0 +1,5 @@
+robocin_cpp_library(
+  NAME coach
+  HDRS icoach.h
+  SRCS icoach.cpp
+)

--- a/decision-ms/decision-guardiola/decision/processing/coach/icoach.cpp
+++ b/decision-ms/decision-guardiola/decision/processing/coach/icoach.cpp
@@ -1,0 +1,1 @@
+#include "decision/processing/coach/icoach.h"

--- a/decision-ms/decision-guardiola/decision/processing/coach/icoach.h
+++ b/decision-ms/decision-guardiola/decision/processing/coach/icoach.h
@@ -1,0 +1,23 @@
+#ifndef DECISION_PROCESSING_COACH_ICOACH_H
+#define DECISION_PROCESSING_COACH_ICOACH_H
+
+#include "decision/processing/evaluators/ievaluator.h"
+
+namespace decision {
+
+class ICoach {
+ public:
+  ICoach() = default;
+
+  ICoach(const ICoach&) = delete;
+  ICoach& operator=(const ICoach&) = delete;
+
+  ICoach(ICoach&&) = default;
+  ICoach& operator=(ICoach&&) = default;
+
+  virtual ~ICoach() = default;
+};
+
+} // namespace decision
+
+#endif /* DECISION_PROCESSING_COACH_ICOACH_H */

--- a/decision-ms/decision-guardiola/decision/processing/coach/tactical_plan/tactical_plan.cpp
+++ b/decision-ms/decision-guardiola/decision/processing/coach/tactical_plan/tactical_plan.cpp
@@ -1,0 +1,7 @@
+#include "decision/processing/coach/tactical_plan/tactical_plan.h"
+
+namespace decision {
+
+TacticalPlan::TacticalPlan() = default;
+
+} // namespace decision

--- a/decision-ms/decision-guardiola/decision/processing/coach/tactical_plan/tactical_plan.h
+++ b/decision-ms/decision-guardiola/decision/processing/coach/tactical_plan/tactical_plan.h
@@ -1,0 +1,13 @@
+#ifndef DECISION_PROCESSING_COACH_TACTICAL_PLAN_TACTICAL_PLAN_H
+#define DECISION_PROCESSING_COACH_TACTICAL_PLAN_TACTICAL_PLAN_H
+
+namespace decision {
+
+class TacticalPlan {
+ public:
+  TacticalPlan();
+};
+
+} // namespace decision
+
+#endif /* DECISION_PROCESSING_COACH_TACTICAL_PLAN_TACTICAL_PLAN_H */

--- a/decision-ms/decision-guardiola/decision/processing/evaluators/CMakeLists.txt
+++ b/decision-ms/decision-guardiola/decision/processing/evaluators/CMakeLists.txt
@@ -1,0 +1,5 @@
+robocin_cpp_library(
+  NAME evaluators
+  HDRS ievaluator.h
+  SRCS ievaluator.cpp
+)

--- a/decision-ms/decision-guardiola/decision/processing/evaluators/ievaluator.cpp
+++ b/decision-ms/decision-guardiola/decision/processing/evaluators/ievaluator.cpp
@@ -1,0 +1,1 @@
+#include "ievaluator.h"

--- a/decision-ms/decision-guardiola/decision/processing/evaluators/ievaluator.h
+++ b/decision-ms/decision-guardiola/decision/processing/evaluators/ievaluator.h
@@ -1,0 +1,21 @@
+#ifndef DECISION_PROCESSING_EVALUATORS_IEVALUATOR_H
+#define DECISION_PROCESSING_EVALUATORS_IEVALUATOR_H
+
+namespace decision {
+
+class IEvaluator {
+ public:
+  IEvaluator() = default;
+
+  IEvaluator(const IEvaluator&) = delete;
+  IEvaluator& operator=(const IEvaluator&) = delete;
+
+  IEvaluator(IEvaluator&&) = default;
+  IEvaluator& operator=(IEvaluator&&) = default;
+
+  virtual ~IEvaluator() = default;
+};
+
+} // namespace decision
+
+#endif /* DECISION_PROCESSING_EVALUATORS_IEVALUATOR_H */


### PR DESCRIPTION
This PR adds the initial interfaces that will be used to structure the decision microservice. Their intention is to facilitate further development and expansion of the decision processing, with each calculation being done in its own evaluator, and with the evaluators being processed in a class that implements `ICoach`.