### PR TITLE
Add methods and implementation of ICoach

### DIFF
--- a/decision-ms/decision-guardiola/decision/processing/coach/CMakeLists.txt
+++ b/decision-ms/decision-guardiola/decision/processing/coach/CMakeLists.txt
@@ -1,7 +1,10 @@
 robocin_cpp_library(
   NAME coach
   HDRS icoach.h
+       coach.h
        tactical_plan/tactical_plan.h
   SRCS icoach.cpp
+       coach.cpp
        tactical_plan/tactical_plan.cpp
+  DEPS evaluators
 )

--- a/decision-ms/decision-guardiola/decision/processing/coach/coach.cpp
+++ b/decision-ms/decision-guardiola/decision/processing/coach/coach.cpp
@@ -1,0 +1,9 @@
+#include "decision/processing/coach/coach.h"
+
+namespace decision {
+
+Coach::Coach() = default;
+
+TacticalPlan Coach::getTacticalPlan() const { return TacticalPlan{}; }
+
+} // namespace decision

--- a/decision-ms/decision-guardiola/decision/processing/coach/coach.h
+++ b/decision-ms/decision-guardiola/decision/processing/coach/coach.h
@@ -1,0 +1,17 @@
+#ifndef DECISION_PROCESSING_COACH_COACH_H
+#define DECISION_PROCESSING_COACH_COACH_H
+
+#include "decision/processing/coach/icoach.h"
+
+namespace decision {
+
+class Coach : public ICoach {
+ public:
+  Coach();
+
+  [[nodiscard]] TacticalPlan getTacticalPlan() const override;
+};
+
+} // namespace decision
+
+#endif /* DECISION_PROCESSING_COACH_COACH_H */

--- a/decision-ms/decision-guardiola/decision/processing/coach/icoach.cpp
+++ b/decision-ms/decision-guardiola/decision/processing/coach/icoach.cpp
@@ -1,1 +1,19 @@
 #include "decision/processing/coach/icoach.h"
+
+namespace decision {
+
+TacticalPlan ICoach::process() const {
+  for (auto evaluator : evaluators_) {
+    evaluator->process();
+  }
+
+  return getTacticalPlan();
+}
+
+void ICoach::reset() {
+  for (auto evaluator : evaluators_) {
+    evaluator->reset();
+  }
+}
+
+} // namespace decision

--- a/decision-ms/decision-guardiola/decision/processing/coach/icoach.h
+++ b/decision-ms/decision-guardiola/decision/processing/coach/icoach.h
@@ -1,7 +1,12 @@
 #ifndef DECISION_PROCESSING_COACH_ICOACH_H
 #define DECISION_PROCESSING_COACH_ICOACH_H
 
+#include "decision/processing/coach/tactical_plan/tactical_plan.h"
 #include "decision/processing/evaluators/ievaluator.h"
+
+#include <concepts>
+#include <memory>
+#include <vector>
 
 namespace decision {
 
@@ -16,6 +21,22 @@ class ICoach {
   ICoach& operator=(ICoach&&) = default;
 
   virtual ~ICoach() = default;
+
+  [[nodiscard]] TacticalPlan process() const;
+  void reset();
+
+ protected:
+  [[nodiscard]] virtual TacticalPlan getTacticalPlan() const = 0;
+
+  template <std::derived_from<IEvaluator> T, class... Args>
+  [[nodiscard]] std::unique_ptr<T> makeEvaluator(Args&&... args) {
+    auto evaluator = std::make_unique<T>(std::forward<Args>(args)...);
+    evaluators_.emplace_back(evaluator);
+    return std::move(evaluator);
+  }
+
+ private:
+  std::vector<IEvaluator*> evaluators_;
 };
 
 } // namespace decision

--- a/decision-ms/decision-guardiola/decision/processing/evaluators/ievaluator.h
+++ b/decision-ms/decision-guardiola/decision/processing/evaluators/ievaluator.h
@@ -14,6 +14,9 @@ class IEvaluator {
   IEvaluator& operator=(IEvaluator&&) = default;
 
   virtual ~IEvaluator() = default;
+
+  virtual void process() = 0;
+  virtual void reset() = 0;
 };
 
 } // namespace decision


### PR DESCRIPTION
This PR adds methods to ICoach interface. Their use is intended to create the evaluators, process and reset them.