### PR TITLE
Add initial decision structure

### DIFF
--- a/decision-ms/decision-guardiola/decision/processing/coach/CMakeLists.txt
+++ b/decision-ms/decision-guardiola/decision/processing/coach/CMakeLists.txt
@@ -1,0 +1,7 @@
+robocin_cpp_library(
+  NAME coach
+  HDRS icoach.h
+       tactical_plan/tactical_plan.h
+  SRCS icoach.cpp
+       tactical_plan/tactical_plan.cpp
+)

--- a/decision-ms/decision-guardiola/decision/processing/coach/icoach.cpp
+++ b/decision-ms/decision-guardiola/decision/processing/coach/icoach.cpp
@@ -1,0 +1,1 @@
+#include "decision/processing/coach/icoach.h"

--- a/decision-ms/decision-guardiola/decision/processing/coach/icoach.h
+++ b/decision-ms/decision-guardiola/decision/processing/coach/icoach.h
@@ -1,0 +1,31 @@
+#ifndef DECISION_PROCESSING_COACH_ICOACH_H
+#define DECISION_PROCESSING_COACH_ICOACH_H
+
+#include "decision/processing/coach/tactical_plan/tactical_plan.h"
+#include "decision/processing/evaluators/ievaluator.h"
+
+#include <memory>
+#include <vector>
+
+namespace decision {
+
+class ICoach {
+ public:
+  ICoach() = default;
+
+  ICoach(const ICoach&) = delete;
+  ICoach& operator=(const ICoach&) = delete;
+
+  ICoach(ICoach&&) = default;
+  ICoach& operator=(ICoach&&) = default;
+
+  virtual ~ICoach() = default;
+
+  virtual void process() = 0;
+  virtual void reset() = 0;
+  virtual TacticalPlan getTacticalPlan() = 0;
+};
+
+} // namespace decision
+
+#endif /* DECISION_PROCESSING_COACH_ICOACH_H */

--- a/decision-ms/decision-guardiola/decision/processing/coach/tactical_plan/tactical_plan.cpp
+++ b/decision-ms/decision-guardiola/decision/processing/coach/tactical_plan/tactical_plan.cpp
@@ -1,0 +1,7 @@
+#include "decision/processing/coach/tactical_plan/tactical_plan.h"
+
+namespace decision {
+
+TacticalPlan::TacticalPlan() = default;
+
+} // namespace decision

--- a/decision-ms/decision-guardiola/decision/processing/coach/tactical_plan/tactical_plan.h
+++ b/decision-ms/decision-guardiola/decision/processing/coach/tactical_plan/tactical_plan.h
@@ -1,0 +1,13 @@
+#ifndef DECISION_PROCESSING_COACH_TACTICAL_PLAN_TACTICAL_PLAN_H
+#define DECISION_PROCESSING_COACH_TACTICAL_PLAN_TACTICAL_PLAN_H
+
+namespace decision {
+
+class TacticalPlan {
+ public:
+  TacticalPlan();
+};
+
+} // namespace decision
+
+#endif /* DECISION_PROCESSING_COACH_TACTICAL_PLAN_TACTICAL_PLAN_H */

--- a/decision-ms/decision-guardiola/decision/processing/evaluators/CMakeLists.txt
+++ b/decision-ms/decision-guardiola/decision/processing/evaluators/CMakeLists.txt
@@ -1,5 +1,7 @@
 robocin_cpp_library(
   NAME evaluators
   HDRS ievaluator.h
+       evaluator_result.h
   SRCS ievaluator.cpp
+       evaluator_result.cpp
 )

--- a/decision-ms/decision-guardiola/decision/processing/evaluators/CMakeLists.txt
+++ b/decision-ms/decision-guardiola/decision/processing/evaluators/CMakeLists.txt
@@ -1,0 +1,5 @@
+robocin_cpp_library(
+  NAME evaluators
+  HDRS ievaluator.h
+  SRCS ievaluator.cpp
+)

--- a/decision-ms/decision-guardiola/decision/processing/evaluators/evaluator_result.cpp
+++ b/decision-ms/decision-guardiola/decision/processing/evaluators/evaluator_result.cpp
@@ -1,0 +1,1 @@
+#include "decision/processing/evaluators/evaluator_result.h"

--- a/decision-ms/decision-guardiola/decision/processing/evaluators/evaluator_result.h
+++ b/decision-ms/decision-guardiola/decision/processing/evaluators/evaluator_result.h
@@ -1,0 +1,21 @@
+#ifndef DECISION_PROCESSING_EVALUATORS_EVALUATOR_RESULT_H
+#define DECISION_PROCESSING_EVALUATORS_EVALUATOR_RESULT_H
+
+namespace decision {
+
+class EvaluatorResult {
+ public:
+  EvaluatorResult() = default;
+
+  EvaluatorResult(const EvaluatorResult&) = default;
+  EvaluatorResult& operator=(const EvaluatorResult&) = default;
+
+  EvaluatorResult(EvaluatorResult&&) = default;
+  EvaluatorResult& operator=(EvaluatorResult&&) = default;
+
+  virtual ~EvaluatorResult() = default;
+};
+
+} // namespace decision
+
+#endif /* DECISION_PROCESSING_EVALUATORS_EVALUATOR_RESULT_H */

--- a/decision-ms/decision-guardiola/decision/processing/evaluators/ievaluator.cpp
+++ b/decision-ms/decision-guardiola/decision/processing/evaluators/ievaluator.cpp
@@ -1,0 +1,1 @@
+#include "ievaluator.h"

--- a/decision-ms/decision-guardiola/decision/processing/evaluators/ievaluator.h
+++ b/decision-ms/decision-guardiola/decision/processing/evaluators/ievaluator.h
@@ -1,0 +1,24 @@
+#ifndef DECISION_PROCESSING_EVALUATORS_IEVALUATOR_H
+#define DECISION_PROCESSING_EVALUATORS_IEVALUATOR_H
+
+namespace decision {
+
+class IEvaluator {
+ public:
+  IEvaluator() = default;
+
+  IEvaluator(const IEvaluator&) = delete;
+  IEvaluator& operator=(const IEvaluator&) = delete;
+
+  IEvaluator(IEvaluator&&) = default;
+  IEvaluator& operator=(IEvaluator&&) = default;
+
+  virtual ~IEvaluator() = default;
+
+  virtual void process() = 0;
+  virtual void reset() = 0;
+};
+
+} // namespace decision
+
+#endif /* DECISION_PROCESSING_EVALUATORS_IEVALUATOR_H */

--- a/decision-ms/decision-guardiola/decision/processing/evaluators/ievaluator.h
+++ b/decision-ms/decision-guardiola/decision/processing/evaluators/ievaluator.h
@@ -3,6 +3,7 @@
 
 namespace decision {
 
+template <class T>
 class IEvaluator {
  public:
   IEvaluator() = default;
@@ -17,6 +18,7 @@ class IEvaluator {
 
   virtual void process() = 0;
   virtual void reset() = 0;
+  virtual T getResult() = 0;
 };
 
 } // namespace decision

--- a/decision-ms/decision-guardiola/decision/processing/evaluators/ievaluator.h
+++ b/decision-ms/decision-guardiola/decision/processing/evaluators/ievaluator.h
@@ -3,7 +3,6 @@
 
 namespace decision {
 
-template <class T>
 class IEvaluator {
  public:
   IEvaluator() = default;
@@ -18,7 +17,6 @@ class IEvaluator {
 
   virtual void process() = 0;
   virtual void reset() = 0;
-  virtual T getResult() = 0;
 };
 
 } // namespace decision

--- a/decision-ms/decision-guardiola/decision/processing/evaluators/ievaluator.h
+++ b/decision-ms/decision-guardiola/decision/processing/evaluators/ievaluator.h
@@ -1,6 +1,7 @@
 #ifndef DECISION_PROCESSING_EVALUATORS_IEVALUATOR_H
 #define DECISION_PROCESSING_EVALUATORS_IEVALUATOR_H
 
+#include "decision/processing/evaluators/evaluator_result.h"
 namespace decision {
 
 class IEvaluator {
@@ -17,6 +18,7 @@ class IEvaluator {
 
   virtual void process() = 0;
   virtual void reset() = 0;
+  virtual EvaluatorResult& getResult() = 0;
 };
 
 } // namespace decision


### PR DESCRIPTION
This PR adds the initial interfaces that will be used to structure the decision microservice. Their intention is to facilitate further development and expansion of the decision processing, with each calculation being done in its own evaluator, and with the evaluators being processed in a class that implements ICoach.
