### PR TITLE
[behavior-ms] Add behavior world class

### DIFF
--- a/behavior-ms/behavior-bruxo/behavior/parameters/parameters.h
+++ b/behavior-ms/behavior-bruxo/behavior/parameters/parameters.h
@@ -9,6 +9,8 @@ namespace behavior {
 constinit const auto pBehaviorPollerTimeoutMs
     = ::robocin::parameters::View<1>::asInt32(10 /*ms ~= 100Hz*/);
 
+constinit const auto pIsYellow = ::robocin::parameters::View<1>::asBool(true);
+
 // NOLINTEND(*comment*)
 } // namespace behavior
 

--- a/behavior-ms/behavior-bruxo/behavior/processing/CMakeLists.txt
+++ b/behavior-ms/behavior-bruxo/behavior/processing/CMakeLists.txt
@@ -4,4 +4,5 @@ robocin_cpp_library(
     SRCS behavior_processor.cpp
     DEPS common::output
          messages
+         entities
 )

--- a/behavior-ms/behavior-bruxo/behavior/processing/behavior_processor.cpp
+++ b/behavior-ms/behavior-bruxo/behavior/processing/behavior_processor.cpp
@@ -68,13 +68,17 @@ std::optional<rc::Behavior> BehaviorProcessor::process(std::span<const Payload> 
   }
   const rc::Detection last_detection = detection_messages.back();
 
+  BehaviorMessage behavior_message;
+
   // TODO: implement the logic to generate the behavior based on the last detection and the last
   // decision
   ///////////////////////////////////////////////////////////////////////////////////
 
-  BehaviorMessage behavior_message;
+  world_.update(last_decision_.value(),
+                {last_detection.robots().begin(), last_detection.robots().end()},
+                last_detection.ball());
 
-  for (const auto& robot : last_detection.robots()) {
+  for (const auto& robot : world_.allies) {
 
     behavior_message.output.emplace_back(
         OutputMessage{RobotIdMessage{}, MotionMessage{}, PlanningMessage{}});

--- a/behavior-ms/behavior-bruxo/behavior/processing/behavior_processor.cpp
+++ b/behavior-ms/behavior-bruxo/behavior/processing/behavior_processor.cpp
@@ -76,10 +76,10 @@ std::optional<rc::Behavior> BehaviorProcessor::process(std::span<const Payload> 
 
   world_.update(last_decision_.value(),
                 {last_detection.robots().begin(), last_detection.robots().end()},
-                last_detection.ball());
+                {last_detection.balls().begin(), last_detection.balls().end()},
+                last_decision_.value());
 
   for (const auto& robot : world_.allies) {
-
     behavior_message.output.emplace_back(
         OutputMessage{RobotIdMessage{}, MotionMessage{}, PlanningMessage{}});
   }

--- a/behavior-ms/behavior-bruxo/behavior/processing/behavior_processor.h
+++ b/behavior-ms/behavior-bruxo/behavior/processing/behavior_processor.h
@@ -2,6 +2,7 @@
 #define BEHAVIOR_PROCESSING_BEHAVIOR_PROCESSOR_H
 
 #include "behavior/messaging/receiver/payload.h"
+#include "behavior/processing/entities/world.h"
 #include "behavior/processing/messages/behavior/behavior_message.h"
 #include "behavior/processing/messages/common/robot_id/robot_id.h"
 #include "behavior/processing/messages/motion/motion_message.h"
@@ -37,6 +38,7 @@ class BehaviorProcessor : public IBehaviorProcessor {
   process(std::span<const Payload> payloads) override;
 
  private:
+  World world_;
   std::unique_ptr<::robocin::parameters::IHandlerEngine> parameters_handler_engine_;
   std::optional<::protocols::decision::Decision> last_decision_;
 };

--- a/behavior-ms/behavior-bruxo/behavior/processing/entities/CMakeLists.txt
+++ b/behavior-ms/behavior-bruxo/behavior/processing/entities/CMakeLists.txt
@@ -2,4 +2,6 @@ robocin_cpp_library(
   NAME entities
   HDRS world.h
   SRCS world.cpp
+  DEPS common::output
+       messages
 )

--- a/behavior-ms/behavior-bruxo/behavior/processing/entities/CMakeLists.txt
+++ b/behavior-ms/behavior-bruxo/behavior/processing/entities/CMakeLists.txt
@@ -1,0 +1,5 @@
+robocin_cpp_library(
+  NAME entities
+  HDRS world.h
+  SRCS world.cpp
+)

--- a/behavior-ms/behavior-bruxo/behavior/processing/entities/world.cpp
+++ b/behavior-ms/behavior-bruxo/behavior/processing/entities/world.cpp
@@ -12,8 +12,8 @@ void World::update(std::optional<DecisionMessage>& decision,
 
   if (robots.has_value()) {
     for (const auto& robot : robots.value()) {
-      bool isAlly = (pIsYellow && robot.color() == RobotMessage::Color::Yellow)
-                    || (!pIsYellow && robot.color() == RobotMessage::Color::Blue);
+      bool isAlly = (pIsYellow() && robot.color() == RobotIdMessage::Color::COLOR_YELLOW)
+                    || (!pIsYellow() && robot.color() == RobotIdMessage::Color::COLOR_BLUE);
 
       if (isAlly) {
         this->allies.push_back(robot_message);
@@ -42,8 +42,8 @@ void World::update(const protocols::decision::Decision& decision,
   for (const auto& robot : robots) {
     RobotMessage robot_message;
     robot_message.fromProto(robot);
-    bool isAlly = (pIsYellow && robot_message.color() == RobotMessage::Color::Yellow)
-                  || (!pIsYellow && robot_message.color() == RobotMessage::Color::Blue);
+    bool isAlly = (pIsYellow() && robot_message.color() == RobotIdMessage::Color::COLOR_YELLOW)
+                  || (!pIsYellow() && robot_message.color() == RobotIdMessage::Color::COLOR_BLUE);
 
     if (isAlly) {
       this->allies.push_back(robot_message);

--- a/behavior-ms/behavior-bruxo/behavior/processing/entities/world.cpp
+++ b/behavior-ms/behavior-bruxo/behavior/processing/entities/world.cpp
@@ -12,8 +12,8 @@ void World::update(std::optional<DecisionMessage>& decision,
 
   if (robots.has_value()) {
     for (const auto& robot : robots.value()) {
-      bool isAlly = (pIsYellow() && robot.robot_id->color == RobotIdMessage::Color::COLOR_YELLOW)
-                    || (!pIsYellow() && robot.robot_id->color == RobotIdMessage::Color::COLOR_BLUE);
+      bool isAlly = (pIsYellow() && robot.robot_id->color == Color::COLOR_YELLOW)
+                    || (!pIsYellow() && robot.robot_id->color == Color::COLOR_BLUE);
 
       if (isAlly) {
         this->allies.push_back(robot_message);
@@ -42,9 +42,8 @@ void World::update(const protocols::decision::Decision& decision,
   for (const auto& robot : robots) {
     RobotMessage robot_message;
     robot_message.fromProto(robot);
-    bool isAlly
-        = (pIsYellow() && robot.robot_id->color == RobotIdMessage::Color::COLOR_YELLOW)
-          || (!pIsYellow() && robot_message.robot_id->color == RobotIdMessage::Color::COLOR_BLUE);
+    bool isAlly = (pIsYellow() && robot_message.robot_id->color == Color::COLOR_YELLOW)
+                  || (!pIsYellow() && robot_message.robot_id->color == Color::COLOR_BLUE);
 
     if (isAlly) {
       this->allies.push_back(robot_message);

--- a/behavior-ms/behavior-bruxo/behavior/processing/entities/world.cpp
+++ b/behavior-ms/behavior-bruxo/behavior/processing/entities/world.cpp
@@ -2,37 +2,37 @@
 
 namespace behavior {
 
-void World::update(std::optional<DecisionMessage>& decision,
-                   std::optional<std::span<RobotMessage>>& robots,
-                   std::optional<BallMessage>& ball) {
+// void World::update(std::optional<DecisionMessage>& decision,
+//                    std::optional<std::span<RobotMessage>>& robots,
+//                    std::optional<BallMessage>& ball) {
 
-  if (decision.has_value()) {
-    this->decision = std::move(decision.value());
-  }
+//   if (decision.has_value()) {
+//     this->decision = std::move(decision.value());
+//   }
 
-  if (robots.has_value()) {
-    for (const auto& robot : robots.value()) {
-      bool isAlly = (pIsYellow() && robot.robot_id->color == Color::COLOR_YELLOW)
-                    || (!pIsYellow() && robot.robot_id->color == Color::COLOR_BLUE);
+//   if (robots.has_value()) {
+//     for (const auto& robot : robots.value()) {
+//       bool isAlly = (pIsYellow() && robot.robot_id->color == Color::COLOR_YELLOW)
+//                     || (!pIsYellow() && robot.robot_id->color == Color::COLOR_BLUE);
 
-      if (isAlly) {
-        this->allies.emplace_back(std::move(robot));
-      } else {
-        this->enemies.emplace_back(std::move(robot));
-      }
-    }
-  }
+//       if (isAlly) {
+//         this->allies.emplace_back(std::move(robot));
+//       } else {
+//         this->enemies.emplace_back(std::move(robot));
+//       }
+//     }
+//   }
 
-  if (ball.has_value()) {
-    // TODO(ersa): get ball with highest confidence
-    this->ball = std::move(ball.value());
-  }
+//   if (ball.has_value()) {
+//     // TODO(ersa): get ball with highest confidence
+//     this->ball = std::move(ball.value());
+//   }
 
-  // if (game_status.has_value()) {
-  //   // TODO(ersa): get last game status
-  //   this->game_status = std::move(game_status.value());
-  // }
-}
+//   // if (game_status.has_value()) {
+//   //   // TODO(ersa): get last game status
+//   //   this->game_status = std::move(game_status.value());
+//   // }
+// }
 
 void World::update(const protocols::decision::Decision& decision,
                    const std::vector<protocols::perception::Robot>& robots,

--- a/behavior-ms/behavior-bruxo/behavior/processing/entities/world.cpp
+++ b/behavior-ms/behavior-bruxo/behavior/processing/entities/world.cpp
@@ -16,9 +16,9 @@ void World::update(std::optional<DecisionMessage>& decision,
                     || (!pIsYellow() && robot.robot_id->color == Color::COLOR_BLUE);
 
       if (isAlly) {
-        this->allies.push_back(robot_message);
+        this->allies.emplace_back(std::move(robot));
       } else {
-        this->enemies.push_back(robot_message);
+        this->enemies.emplace_back(std::move(robot));
       }
     }
   }
@@ -28,14 +28,14 @@ void World::update(std::optional<DecisionMessage>& decision,
     this->ball = std::move(ball.value());
   }
 
-  if (game_status.has_value()) {
-    // TODO(ersa): get last game status
-    this->game_status = std::move(game_status.value());
-  }
+  // if (game_status.has_value()) {
+  //   // TODO(ersa): get last game status
+  //   this->game_status = std::move(game_status.value());
+  // }
 }
 
 void World::update(const protocols::decision::Decision& decision,
-                   const std::vector<protocols::perception::Detection>& robots,
+                   const std::vector<protocols::perception::Robot>& robots,
                    const protocols::perception::Ball& ball) {
   this->decision.fromProto(decision);
 
@@ -46,9 +46,9 @@ void World::update(const protocols::decision::Decision& decision,
                   || (!pIsYellow() && robot_message.robot_id->color == Color::COLOR_BLUE);
 
     if (isAlly) {
-      this->allies.push_back(robot_message);
+      this->allies.emplace_back(std::move(robot_message));
     } else {
-      this->enemies.push_back(robot_message);
+      this->enemies.emplace_back(std::move(robot_message));
     }
   }
 

--- a/behavior-ms/behavior-bruxo/behavior/processing/entities/world.cpp
+++ b/behavior-ms/behavior-bruxo/behavior/processing/entities/world.cpp
@@ -12,8 +12,8 @@ void World::update(std::optional<DecisionMessage>& decision,
 
   if (robots.has_value()) {
     for (const auto& robot : robots.value()) {
-      bool isAlly = (pIsYellow() && robot.color() == RobotIdMessage::Color::COLOR_YELLOW)
-                    || (!pIsYellow() && robot.color() == RobotIdMessage::Color::COLOR_BLUE);
+      bool isAlly = (pIsYellow() && robot.robot_id->color == RobotIdMessage::Color::COLOR_YELLOW)
+                    || (!pIsYellow() && robot.robot_id->color == RobotIdMessage::Color::COLOR_BLUE);
 
       if (isAlly) {
         this->allies.push_back(robot_message);
@@ -42,8 +42,9 @@ void World::update(const protocols::decision::Decision& decision,
   for (const auto& robot : robots) {
     RobotMessage robot_message;
     robot_message.fromProto(robot);
-    bool isAlly = (pIsYellow() && robot_message.color() == RobotIdMessage::Color::COLOR_YELLOW)
-                  || (!pIsYellow() && robot_message.color() == RobotIdMessage::Color::COLOR_BLUE);
+    bool isAlly
+        = (pIsYellow() && robot.robot_id->color == RobotIdMessage::Color::COLOR_YELLOW)
+          || (!pIsYellow() && robot_message.robot_id->color == RobotIdMessage::Color::COLOR_BLUE);
 
     if (isAlly) {
       this->allies.push_back(robot_message);

--- a/behavior-ms/behavior-bruxo/behavior/processing/entities/world.cpp
+++ b/behavior-ms/behavior-bruxo/behavior/processing/entities/world.cpp
@@ -1,0 +1,37 @@
+#include "behavior/processing/entities/world.h"
+
+#include <robocin/output/log.h>
+
+namespace behavior {
+
+namespace {
+using robocin::ilog;
+} // namespace
+
+void World::update(std::optional<DecisionMessage>& decision,
+                   std::optional<std::span<RobotMessage>>& robots,
+                   std::optional<BallMessage>& ball) {
+
+  if (decision.has_value()) {
+    this->decision = std::move(decision.value());
+  }
+
+  if (robots.has_value()) {
+    // TODO(ersa): implement the logic to separate allies and enemies
+    this->allies = robots.value();
+  }
+
+  // if (enemies.has_value()) {
+  //   this->enemies = enemies.value();
+  // }
+
+  if (ball.has_value()) {
+    this->ball = std::move(ball.value());
+  }
+
+  // if (game_status.has_value()) {
+  //   this->game_status = std::move(game_status.value());
+  // }
+}
+
+} // namespace behavior

--- a/behavior-ms/behavior-bruxo/behavior/processing/entities/world.h
+++ b/behavior-ms/behavior-bruxo/behavior/processing/entities/world.h
@@ -31,9 +31,9 @@ class World {
   std::vector<RobotMessage> allies;
   std::vector<RobotMessage> enemies;
 
-  void update(std::optional<DecisionMessage>& decision,
-              std::optional<std::span<RobotMessage>>& robots,
-              std::optional<BallMessage>& ball);
+  //   void update(std::optional<DecisionMessage>& decision,
+  //               std::optional<std::span<RobotMessage>>& robots,
+  //               std::optional<BallMessage>& ball);
 
   void update(const protocols::decision::Decision& decision,
               const std::vector<protocols::perception::Robot>& robots,

--- a/behavior-ms/behavior-bruxo/behavior/processing/entities/world.h
+++ b/behavior-ms/behavior-bruxo/behavior/processing/entities/world.h
@@ -1,0 +1,36 @@
+#ifndef BEHAVIOR_PROCESSING_ENTITIES_WORLD_H
+#define BEHAVIOR_PROCESSING_ENTITIES_WORLD_H
+
+#include "behavior/processing/messages/decision/decision_message.h"
+#include "behavior/processing/messages/perception/ball/ball_message.h"
+#include "behavior/processing/messages/perception/robot/robot_message.h"
+#include "behavior/processing/messages/referee/game_status_message.h"
+
+namespace behavior {
+
+class World {
+ public:
+  World() = default;
+
+  World(const World&) = delete;
+  World& operator=(const World&) = delete;
+  World(World&&) noexcept = default;
+  World& operator=(World&&) noexcept = default;
+
+  virtual ~World() = default;
+
+  BallMessage ball;
+  DecisionMessage decision;
+  //   GameStatusMessage game_status;
+
+  std::span<RobotMessage> allies;
+  std::span<RobotMessage> enemies;
+
+  void update(std::optional<DecisionMessage>& decision,
+              std::optional<std::span<RobotMessage>>& robots,
+              std::optional<BallMessage>& ball);
+};
+
+} // namespace behavior
+
+#endif // DECISION_PROCESSING_ENTITIES_WORLD_H

--- a/behavior-ms/behavior-bruxo/behavior/processing/entities/world.h
+++ b/behavior-ms/behavior-bruxo/behavior/processing/entities/world.h
@@ -1,6 +1,7 @@
 #ifndef BEHAVIOR_PROCESSING_ENTITIES_WORLD_H
 #define BEHAVIOR_PROCESSING_ENTITIES_WORLD_H
 
+#include "behavior/parameters/parameters.h"
 #include "behavior/processing/messages/decision/decision_message.h"
 #include "behavior/processing/messages/perception/ball/ball_message.h"
 #include "behavior/processing/messages/perception/robot/robot_message.h"
@@ -9,7 +10,6 @@
 #include <protocols/behavior/behavior_unification.pb.h>
 #include <protocols/decision/decision.pb.h>
 #include <protocols/perception/detection.pb.h>
-#include <robocin/parameters/parameters.h>
 
 namespace behavior {
 

--- a/behavior-ms/behavior-bruxo/behavior/processing/entities/world.h
+++ b/behavior-ms/behavior-bruxo/behavior/processing/entities/world.h
@@ -32,7 +32,7 @@ class World {
   std::vector<RobotMessage> enemies;
 
   void update(std::optional<DecisionMessage>& decision,
-              std::optional<std::vector<RobotMessage>>& robots,
+              std::optional<std::span<RobotMessage>>& robots,
               std::optional<BallMessage>& ball);
 
   void update(const protocols::decision::Decision& decision,

--- a/behavior-ms/behavior-bruxo/behavior/processing/entities/world.h
+++ b/behavior-ms/behavior-bruxo/behavior/processing/entities/world.h
@@ -6,6 +6,11 @@
 #include "behavior/processing/messages/perception/robot/robot_message.h"
 #include "behavior/processing/messages/referee/game_status_message.h"
 
+#include <protocols/behavior/behavior_unification.pb.h>
+#include <protocols/decision/decision.pb.h>
+#include <protocols/perception/detection.pb.h>
+#include <robocin/parameters/parameters.h>
+
 namespace behavior {
 
 class World {
@@ -29,6 +34,10 @@ class World {
   void update(std::optional<DecisionMessage>& decision,
               std::optional<std::span<RobotMessage>>& robots,
               std::optional<BallMessage>& ball);
+
+  void update(const protocols::decision::Decision& decision,
+              const std::vector<protocols::perception::Detection>& robots,
+              const protocols::perception::Ball& ball);
 };
 
 } // namespace behavior

--- a/behavior-ms/behavior-bruxo/behavior/processing/entities/world.h
+++ b/behavior-ms/behavior-bruxo/behavior/processing/entities/world.h
@@ -10,6 +10,8 @@
 #include <protocols/behavior/behavior_unification.pb.h>
 #include <protocols/decision/decision.pb.h>
 #include <protocols/perception/detection.pb.h>
+#include <protocols/referee/game_status.pb.h>
+#include <vector>
 
 namespace behavior {
 
@@ -26,7 +28,7 @@ class World {
 
   BallMessage ball;
   DecisionMessage decision;
-  //   GameStatusMessage game_status;
+  GameStatusMessage game_status;
 
   std::vector<RobotMessage> allies;
   std::vector<RobotMessage> enemies;
@@ -37,7 +39,14 @@ class World {
 
   void update(const protocols::decision::Decision& decision,
               const std::vector<protocols::perception::Robot>& robots,
-              const protocols::perception::Ball& ball);
+              const std::vector<protocols::perception::Ball>& balls,
+              const protocols::referee::GameStatus& game_status);
+
+ private:
+  void takeBallHighConfidence(const std::vector<protocols::perception::Ball>& balls);
+  void takeAlliesAndEnemies(const std::vector<protocols::perception::Robot>& robots);
+  void takeDecision(const protocols::decision::Decision& decision);
+  void takeGameStatus(const protocols::referee::GameStatus& game_status);
 };
 
 } // namespace behavior

--- a/behavior-ms/behavior-bruxo/behavior/processing/entities/world.h
+++ b/behavior-ms/behavior-bruxo/behavior/processing/entities/world.h
@@ -28,15 +28,15 @@ class World {
   DecisionMessage decision;
   //   GameStatusMessage game_status;
 
-  std::span<RobotMessage> allies;
-  std::span<RobotMessage> enemies;
+  std::vector<RobotMessage> allies;
+  std::vector<RobotMessage> enemies;
 
   void update(std::optional<DecisionMessage>& decision,
-              std::optional<std::span<RobotMessage>>& robots,
+              std::optional<std::vector<RobotMessage>>& robots,
               std::optional<BallMessage>& ball);
 
   void update(const protocols::decision::Decision& decision,
-              const std::vector<protocols::perception::Detection>& robots,
+              const std::vector<protocols::perception::Robot>& robots,
               const protocols::perception::Ball& ball);
 };
 

--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -230,7 +230,7 @@ services:
       dockerfile: behavior-ms/behavior-bruxo/behavior-bruxo.Dockerfile
     volumes:
       - .ssl-core:/tmp/.ssl-core
-    attach: false
+    attach: true
   
   communication-ms:
     container_name: communication-ms


### PR DESCRIPTION
This PR add a world to behavior service processing.

World contains:
- Allies (RobotMessage)
- Enemies (RobotMessage)
- Ball (BallMessage) -> get ball with highest confidence
- GameStatus (GameStatusMessage)