### PR TITLE
[common] Add Line class to `geometry`

### DIFF
--- a/common/cpp/robocin/geometry/CMakeLists.txt
+++ b/common/cpp/robocin/geometry/CMakeLists.txt
@@ -3,7 +3,9 @@ robocin_cpp_library(
   HDRS point2d.h
        point3d.h
        mathematics.h
+       line.h
   SRCS point2d.cpp
        point3d.cpp
        mathematics.cpp
+       line.cpp
 )

--- a/common/cpp/robocin/geometry/line.cpp
+++ b/common/cpp/robocin/geometry/line.cpp
@@ -1,0 +1,1 @@
+#include "robocin/geometry/line.h"

--- a/common/cpp/robocin/geometry/line.h
+++ b/common/cpp/robocin/geometry/line.h
@@ -1,0 +1,33 @@
+#ifndef ROBOCIN_GEOMETRY_LINE_H
+#define ROBOCIN_GEOMETRY_LINE_H
+
+namespace robocin {
+
+template <class PT>
+struct Line {
+
+    PT pt1, pt2;
+
+    // Constructors:
+    inline constexpr Line() = default;
+    inline constexpr Line(const PT& pt1, const PT& pt2) : pt1(pt1), pt2(pt2) {};
+
+    // Line comparison:
+    inline constexpr bool operator==(const Line& other) const {
+        return pt1 == other.pt1 and pt2 == other.pt2;
+    }
+
+    // Setters:
+    inline constexpr void setP1(const PT& pt1) { this->pt1 = pt1; };
+    inline constexpr void setP2(const PT& pt2) { this->pt2 = pt2; };
+    inline constexpr void setPoints(const PT& pt1, const PT& pt2) { this->pt1 = pt1, this->pt2 = pt2; };
+
+    // Getters:
+    inline constexpr PT p1() const { return pt1; };
+    inline constexpr PT p2() const { return pt2; };
+};
+
+} // namespace robocin
+
+
+#endif // ROBOCIN_GEOMETRY_LINE_H


### PR DESCRIPTION
This pr adds a line class to assist with usage in geometry functions.