### PR TITLE
[navigation-ms] Add MoveState Entity

### DIFF
--- a/navigation-ms/navigation-luffy/navigation/processing/entities/CMakeLists.txt
+++ b/navigation-ms/navigation-luffy/navigation/processing/entities/CMakeLists.txt
@@ -1,7 +1,9 @@
 robocin_cpp_library(
   NAME navigation_entities
   HDRS robot_move.h
+       move_state.h
   SRCS robot_move.cpp
+       move_state.cpp
   DEPS common::geometry 
        protocols::protobufs
 )

--- a/navigation-ms/navigation-luffy/navigation/processing/entities/move_state.cpp
+++ b/navigation-ms/navigation-luffy/navigation/processing/entities/move_state.cpp
@@ -1,0 +1,20 @@
+#include "navigation/processing/entities/move_state.h"
+
+namespace navigation {
+MoveState::MoveState(::robocin::Point2Dd velocity,
+                     ::robocin::Point2Dd position,
+                     double angular_velocity,
+                     double angle) :
+    velocity_(velocity),
+    position_(position),
+    angular_velocity_(angular_velocity),
+    angle_(angle) {}
+
+::robocin::Point2Dd MoveState::velocity() const { return velocity_; }
+
+::robocin::Point2Dd MoveState::position() const { return position_; }
+
+double MoveState::angularVelocity() const { return angular_velocity_; }
+
+double MoveState::angle() const { return angle_; }
+} // namespace navigation

--- a/navigation-ms/navigation-luffy/navigation/processing/entities/move_state.h
+++ b/navigation-ms/navigation-luffy/navigation/processing/entities/move_state.h
@@ -1,0 +1,28 @@
+#ifndef NAVIGATION_PROCESSING_MOVE_STATE_H
+#define NAVIGATION_PROCESSING_MOVE_STATE_H
+
+#include <robocin/geometry/point2d.h>
+
+namespace navigation {
+
+class MoveState {
+  ::robocin::Point2Dd velocity_;
+  ::robocin::Point2Dd position_;
+  double angular_velocity_;
+  double angle_;
+
+ public:
+  MoveState(::robocin::Point2Dd velocity,
+            ::robocin::Point2Dd position,
+            double angular_velocity,
+            double angle);
+
+  [[nodiscard]] ::robocin::Point2Dd velocity() const;
+  [[nodiscard]] ::robocin::Point2Dd position() const;
+  [[nodiscard]] double angularVelocity() const;
+  [[nodiscard]] double angle() const;
+};
+
+} // namespace navigation
+
+#endif // NAVIGATION_PROCESSING_MOVE_STATE_H

--- a/navigation-ms/navigation-luffy/navigation/processing/entities/move_state.h
+++ b/navigation-ms/navigation-luffy/navigation/processing/entities/move_state.h
@@ -6,6 +6,7 @@
 namespace navigation {
 
 class MoveState {
+ protected:
   ::robocin::Point2Dd velocity_;
   ::robocin::Point2Dd position_;
   double angular_velocity_;


### PR DESCRIPTION
MoveState is an entity that contains data about the robot's estimated velocity and position for the trajectory calculation. This entity is used in the Navigation's planning