### PR TITLE
[behavior-ms] BehaviorId mapping functions

### DIFF
--- a/behavior-ms/behavior-bruxo/behavior/processing/messages/decision/decision_message.cpp
+++ b/behavior-ms/behavior-bruxo/behavior/processing/messages/decision/decision_message.cpp
@@ -1,6 +1,33 @@
 #include "behavior/processing/messages/decision/decision_message.h"
 
+#include <protocols/decision/decision.pb.h>
+
 namespace behavior {
+
+protocols::decision::Behavior::BehaviorId
+getProtoBehaviorId(BehaviorDecisionMessage::BehaviorId id) {
+  switch (id) {
+    case BehaviorDecisionMessage::BehaviorId::UNSPECIFIED:
+      return protocols::decision::Behavior::BehaviorId::Behavior_BehaviorId_UNSPECIFIED;
+    case BehaviorDecisionMessage::BehaviorId::GOALKEEPER:
+      return protocols::decision::Behavior::BehaviorId::Behavior_BehaviorId_GOALKEEPER;
+    case BehaviorDecisionMessage::BehaviorId::FORWARD:
+      return protocols::decision::Behavior::BehaviorId::Behavior_BehaviorId_FORWARD;
+  }
+  return protocols::decision::Behavior::BehaviorId::Behavior_BehaviorId_UNSPECIFIED;
+}
+
+BehaviorDecisionMessage::BehaviorId getBehaviorId(protocols::decision::Behavior::BehaviorId id) {
+  switch (id) {
+    case protocols::decision::Behavior::BehaviorId::Behavior_BehaviorId_UNSPECIFIED:
+      return BehaviorDecisionMessage::BehaviorId::UNSPECIFIED;
+    case protocols::decision::Behavior::BehaviorId::Behavior_BehaviorId_GOALKEEPER:
+      return BehaviorDecisionMessage::BehaviorId::GOALKEEPER;
+    case protocols::decision::Behavior::BehaviorId::Behavior_BehaviorId_FORWARD:
+      return BehaviorDecisionMessage::BehaviorId::FORWARD;
+  }
+  return BehaviorDecisionMessage::BehaviorId::UNSPECIFIED;
+}
 
 BehaviorDecisionMessage::BehaviorDecisionMessage() :
     id(std::nullopt),
@@ -10,7 +37,7 @@ BehaviorDecisionMessage::BehaviorDecisionMessage() :
 protocols::decision::Behavior BehaviorDecisionMessage::toProto() const {
   protocols::decision::Behavior behavior_proto;
 
-  behavior_proto.set_id(id.value_or(0));
+  behavior_proto.set_id(getProtoBehaviorId(id.value()));
   *behavior_proto.mutable_robot_id() = robot_id.value().toProto();
   behavior_proto.mutable_target()->set_x(target->x);
   behavior_proto.mutable_target()->set_y(target->y);
@@ -19,7 +46,7 @@ protocols::decision::Behavior BehaviorDecisionMessage::toProto() const {
 }
 
 void BehaviorDecisionMessage::fromProto(const protocols::decision::Behavior& behavior_proto) {
-  id = behavior_proto.id();
+  id = getBehaviorId(behavior_proto.id());
   if (behavior_proto.has_robot_id()) {
     robot_id = RobotIdMessage{};
     robot_id->fromProto(behavior_proto.robot_id());

--- a/behavior-ms/behavior-bruxo/behavior/processing/messages/decision/decision_message.h
+++ b/behavior-ms/behavior-bruxo/behavior/processing/messages/decision/decision_message.h
@@ -9,13 +9,19 @@ namespace behavior {
 
 class BehaviorDecisionMessage : public robocin::IProtoConvertible<protocols::decision::Behavior> {
  public:
+  enum BehaviorId {
+    UNSPECIFIED = 0,
+    GOALKEEPER = 1,
+    FORWARD = 2
+  };
+
   BehaviorDecisionMessage();
 
   [[nodiscard]] protocols::decision::Behavior toProto() const override;
 
   void fromProto(const protocols::decision::Behavior& behavior) override;
 
-  std::optional<uint32_t> id;
+  std::optional<BehaviorId> id;
   std::optional<RobotIdMessage> robot_id;
   std::optional<robocin::Point2Df> target;
 };


### PR DESCRIPTION
Add `BehaviorMessage` convertion functions for `BehaviorMessage::BehaviorId` from and to `.proto`.  