### PR TITLE
[CBR] GoToPoint and Kick forward

### DIFF
--- a/behavior-ms/behavior-bruxo/behavior/parameters/parameters.h
+++ b/behavior-ms/behavior-bruxo/behavior/parameters/parameters.h
@@ -11,7 +11,7 @@ namespace behavior {
 constinit const auto pBehaviorPollerTimeoutMs
     = ::robocin::parameters::View<1>::asInt32(10 /*ms ~= 100Hz*/);
 
-constinit const auto pAllyColor = Color::COLOR_BLUE;
+constinit const auto pAllyColor = Color::COLOR_YELLOW;
 
 constinit const auto isAttackingToRight = ::robocin::parameters::View<1>::asBool(true);
 

--- a/behavior-ms/behavior-bruxo/behavior/parameters/parameters.h
+++ b/behavior-ms/behavior-bruxo/behavior/parameters/parameters.h
@@ -11,7 +11,7 @@ namespace behavior {
 constinit const auto pBehaviorPollerTimeoutMs
     = ::robocin::parameters::View<1>::asInt32(10 /*ms ~= 100Hz*/);
 
-constinit const auto pAllyColor = Color::COLOR_YELLOW;
+constinit const auto pAllyColor = Color::COLOR_BLUE;
 
 constinit const auto isAttackingToRight = ::robocin::parameters::View<1>::asBool(true);
 

--- a/behavior-ms/behavior-bruxo/behavior/processing/behavior_processor.cpp
+++ b/behavior-ms/behavior-bruxo/behavior/processing/behavior_processor.cpp
@@ -99,10 +99,8 @@ std::optional<rc::Behavior> onRun(World& world) {
   auto robot = findMyRobot(forward_number, world.allies);
   if (!robot.has_value()) {
     ilog("Robot with id {} not found from detection packets.", forward_number);
-    return;
-  } else {
-    ilog("Robot with id {} found.", forward_number);
-  }
+    return std::nullopt;
+  } 
 
   // Ball 2D is required because .angle() method is implemented from a Point2Df object.
   auto ball_2_d = robocin::Point2Df(world.ball.position->x, world.ball.position->y);
@@ -116,7 +114,7 @@ std::optional<rc::Behavior> onRun(World& world) {
         7.0 /* strength */,
         true /* is_front */,
         false /* is_chip */,
-        false /* charge_capacitor */,
+        false /* charge_capacitor -> makeChargeCapacitor based on distance to ball */,
         false /* bypass_ir */
     }});
   }
@@ -153,9 +151,9 @@ std::optional<rc::Behavior> BehaviorProcessor::process(std::span<const Payload> 
     return std::nullopt;
   }
 
-  // if (world_.isHalt()) {
-  //   return onHalt();
-  // }
+  if (world_.isHalt()) {
+    return onHalt();
+  }
 
   if (!world_.isStop()) {
     return onRun(world_);

--- a/behavior-ms/behavior-bruxo/behavior/processing/behavior_processor.cpp
+++ b/behavior-ms/behavior-bruxo/behavior/processing/behavior_processor.cpp
@@ -91,11 +91,12 @@ std::vector<rc::GameStatus> gameStatusFromPayloads(std::span<const Payload> payl
 // CBR: function for every game command
 void onRun(BehaviorMessage& behavior_message, World& world) {
   // Take forward
-  int forward_number = 2;
+  int forward_number = 7;
 
   auto robot = findMyRobot(forward_number, world.allies);
   if (!robot.has_value()) {
     ilog("Robot with id {} not found from detection packets.", forward_number);
+    return;
   }
 
   // Ball 2D is required because .angle() method is implemented from a Point2Df object.

--- a/behavior-ms/behavior-bruxo/behavior/processing/behavior_processor.cpp
+++ b/behavior-ms/behavior-bruxo/behavior/processing/behavior_processor.cpp
@@ -93,10 +93,14 @@ void onRun(BehaviorMessage& behavior_message, World& world) {
   // Take forward
   int forward_number = 7;
 
+  ilog("Allies detected: {}", world.allies.size());
+
   auto robot = findMyRobot(forward_number, world.allies);
   if (!robot.has_value()) {
     ilog("Robot with id {} not found from detection packets.", forward_number);
     return;
+  } else {
+    ilog("Robot with id {} found.", forward_number);
   }
 
   // Ball 2D is required because .angle() method is implemented from a Point2Df object.

--- a/behavior-ms/behavior-bruxo/behavior/processing/behavior_processor.h
+++ b/behavior-ms/behavior-bruxo/behavior/processing/behavior_processor.h
@@ -39,11 +39,12 @@ class BehaviorProcessor : public IBehaviorProcessor {
  public:
   explicit BehaviorProcessor(
       std::unique_ptr<::robocin::parameters::IHandlerEngine> parameters_handler_engine,
-      std::unique_ptr<::behavior::GoalkeeperTakeBallAwayStateMachine>
-          goalkeeper_take_ball_away_state_machine);
+      std::unique_ptr<GoalkeeperTakeBallAwayStateMachine> goalkeeper_take_ball_away_state_machine);
 
   std::optional<::protocols::behavior::unification::Behavior>
   process(std::span<const Payload> payloads) override;
+
+  bool update(std::span<const Payload>& payloads);
 
  private:
   World world_;

--- a/behavior-ms/behavior-bruxo/behavior/processing/entities/world.cpp
+++ b/behavior-ms/behavior-bruxo/behavior/processing/entities/world.cpp
@@ -65,4 +65,8 @@ void World::update(const std::vector<protocols::perception::Robot>& robots,
   World::takeGameStatus(game_status);
 }
 
+bool World::isStop() { return game_status.command->stop.has_value(); }
+
+bool World::isHalt() { return game_status.command->halt.has_value(); }
+
 } // namespace behavior

--- a/behavior-ms/behavior-bruxo/behavior/processing/entities/world.h
+++ b/behavior-ms/behavior-bruxo/behavior/processing/entities/world.h
@@ -40,10 +40,14 @@ class World {
               const protocols::perception::Field& field,
               const protocols::referee::GameStatus& game_status);
 
+  // CBR: checker for every command
+  bool isStop();
+  bool isHalt();
+
  private:
   void takeBallHighConfidence(const std::vector<protocols::perception::Ball>& balls);
   void takeAlliesAndEnemies(const std::vector<protocols::perception::Robot>& robots);
-  void takeDecision(const protocols::decision::Decision& decision);
+  void takeDecision(const protocols::decision::Decision& decision); // unused in cbr early version
   void takeGameStatus(const protocols::referee::GameStatus& game_status);
   void takeField(const protocols::perception::Field& field);
 

--- a/behavior-ms/behavior-bruxo/behavior/processing/messages/common/peripheral_actuation/peripheral_actuation.cpp
+++ b/behavior-ms/behavior-bruxo/behavior/processing/messages/common/peripheral_actuation/peripheral_actuation.cpp
@@ -12,9 +12,7 @@ void PeripheralActuationMessage::fromProto(
 
 protocols::common::PeripheralActuation PeripheralActuationMessage::toProto() const {
   protocols::common::PeripheralActuation proto;
-  std::printf("OIIIIII");
-  robocin::ilog("{} {} {} {} {}", kick_command.strength, kick_command.is_front, kick_command.is_chip, kick_command.charge_capacitor, kick_command.is_bypass_ir);
-
+  
   proto.mutable_kick_command()->CopyFrom(kick_command.toProto());
 
   return proto;

--- a/behavior-ms/behavior-bruxo/behavior/processing/messages/common/peripheral_actuation/peripheral_actuation.cpp
+++ b/behavior-ms/behavior-bruxo/behavior/processing/messages/common/peripheral_actuation/peripheral_actuation.cpp
@@ -1,4 +1,5 @@
 #include "behavior/processing/messages/common/peripheral_actuation/peripheral_actuation.h"
+#include <robocin/output/log.h>
 
 #include "behavior/processing/messages/common/robot_kick/kick_command.h"
 
@@ -10,6 +11,12 @@ void PeripheralActuationMessage::fromProto(
     const protocols::common::PeripheralActuation& peripheral_actuation_proto) {};
 
 protocols::common::PeripheralActuation PeripheralActuationMessage::toProto() const {
-  return protocols::common::PeripheralActuation{};
+  protocols::common::PeripheralActuation proto;
+  std::printf("OIIIIII");
+  robocin::ilog("{} {} {} {} {}", kick_command.strength, kick_command.is_front, kick_command.is_chip, kick_command.charge_capacitor, kick_command.is_bypass_ir);
+
+  proto.mutable_kick_command()->CopyFrom(kick_command.toProto());
+
+  return proto;
 };
 } // namespace behavior

--- a/behavior-ms/behavior-bruxo/behavior/processing/messages/common/robot_kick/kick_command.cpp
+++ b/behavior-ms/behavior-bruxo/behavior/processing/messages/common/robot_kick/kick_command.cpp
@@ -14,7 +14,15 @@ KickCommandMessage::KickCommandMessage(float strength,
     is_bypass_ir(is_bypass_ir) {};
 
 [[nodiscard]] protocols::common::RobotKick::KickCommand KickCommandMessage::toProto() const {
-  return protocols::common::RobotKick::KickCommand{};
+  protocols::common::RobotKick::KickCommand proto;
+
+  proto.set_kick_strength(strength);
+  proto.set_is_front(is_front);
+  proto.set_is_chip(is_chip);
+  proto.set_charge_capacitor(charge_capacitor);
+  proto.set_is_bypass_ir(is_bypass_ir);
+
+  return proto;
 };
 
 void KickCommandMessage::fromProto(

--- a/behavior-ms/behavior-bruxo/behavior/processing/messages/motion/motion_message.cpp
+++ b/behavior-ms/behavior-bruxo/behavior/processing/messages/motion/motion_message.cpp
@@ -64,7 +64,7 @@ MotionMessage::MotionMessage(
     go_to_point_with_trajectory{std::move(go_to_point_with_trajectory)},
     rotate_in_point{std::move(rotate_in_point)},
     rotate_on_self{std::move(rotate_on_self)},
-    peripheral_actuation(std::move(peripheral_actuation)) {}
+    peripheral_actuation{std::move(peripheral_actuation)} {}
 
 protocols::behavior::unification::Motion MotionMessage::toProto() const {
   protocols::behavior::unification::Motion motion;
@@ -72,18 +72,26 @@ protocols::behavior::unification::Motion MotionMessage::toProto() const {
     motion.set_allocated_go_to_point(
         new protocols::behavior::GoToPoint(go_to_point.value().toProto()));
   }
+
   if (go_to_point_with_trajectory.has_value()) {
     motion.set_allocated_go_to_point_with_trajectory(
         new protocols::behavior::GoToPointWithTrajectory(
             go_to_point_with_trajectory.value().toProto()));
   }
+
   if (rotate_in_point.has_value()) {
     motion.set_allocated_rotate_in_point(
         new protocols::behavior::RotateInPoint(rotate_in_point.value().toProto()));
   }
+
   if (rotate_on_self.has_value()) {
     motion.set_allocated_rotate_on_self(
         new protocols::behavior::RotateOnSelf(rotate_on_self.value().toProto()));
+  }
+
+  if (peripheral_actuation.has_value()) {
+    motion.set_allocated_peripheral_actuation(
+        new protocols::common::PeripheralActuation(peripheral_actuation.value().toProto()));
   }
 
   return motion;

--- a/communication-ms/communication-jaiminho/communication/messaging/receiver/payload_mapper.cpp
+++ b/communication-ms/communication-jaiminho/communication/messaging/receiver/payload_mapper.cpp
@@ -46,7 +46,7 @@ Payload PayloadMapper::fromZmqDatagrams(std::span<const ZmqDatagram> messages) c
       referee.emplace_back(std::move(referee_message));
 
     } else {
-      // wlog("zmq_datagram with topic '{}' not processed.", zmq_datagram.topic());
+      wlog("zmq_datagram with topic '{}' not processed.", zmq_datagram.topic());
     }
   }
 

--- a/communication-ms/communication-jaiminho/communication/messaging/receiver/payload_mapper.cpp
+++ b/communication-ms/communication-jaiminho/communication/messaging/receiver/payload_mapper.cpp
@@ -37,7 +37,7 @@ Payload PayloadMapper::fromZmqDatagrams(std::span<const ZmqDatagram> messages) c
     if (zmq_datagram.topic() == service_discovery::kNavigationOutputTopic) {
       rc::Navigation navigation_message;
       navigation_message.ParseFromString(std::string{zmq_datagram.message()});
-      // robocin::ilog("Received from navigation: {}", navigation_message.DebugString());
+      robocin::ilog("Received from navigation: {}", navigation_message.DebugString());
       navigation.emplace_back(std::move(navigation_message));
 
     } else if (zmq_datagram.topic() == service_discovery::kGameControllerRefereeTopic) {

--- a/communication-ms/communication-jaiminho/communication/processing/communication_processor.cpp
+++ b/communication-ms/communication-jaiminho/communication/processing/communication_processor.cpp
@@ -71,7 +71,7 @@ CommunicationProcessor::process(std::span<const Payload> payloads) {
         navigation.angular_velocity(),
         navigation.peripheral_actuation().kick_command().is_front(),
         navigation.peripheral_actuation().kick_command().is_chip(),
-        true /* always charge */,
+        false /* always charge */,
         navigation.peripheral_actuation().kick_command().kick_strength(),
         false /* dribbler always off */,
         0.0 /* dribbler speed unused */

--- a/communication-ms/communication-jaiminho/communication/processing/communication_processor.cpp
+++ b/communication-ms/communication-jaiminho/communication/processing/communication_processor.cpp
@@ -71,7 +71,7 @@ CommunicationProcessor::process(std::span<const Payload> payloads) {
         navigation.angular_velocity(),
         navigation.peripheral_actuation().kick_command().is_front(),
         navigation.peripheral_actuation().kick_command().is_chip(),
-        false /* always charge */,
+        navigation.peripheral_actuation().kick_command().charge_capacitor(), /* always false */,
         navigation.peripheral_actuation().kick_command().kick_strength(),
         false /* dribbler always off */,
         0.0 /* dribbler speed unused */

--- a/docker-compose.cbr.yaml
+++ b/docker-compose.cbr.yaml
@@ -1,17 +1,17 @@
 services:
-  ssl-vision-client:
-    container_name: ssl-vision-client
-    image: robocupssl/ssl-vision-client:1.7.3
-    command:
-      - "-visionAddress"
-      - "224.5.23.2:10006"
-    restart: unless-stopped
-    ports:
-      - 8082/tcp
-      - 8082:8082
-    logging:
-      driver: none
-    network_mode: host
+  # ssl-vision-client:
+  #   container_name: ssl-vision-client
+  #   image: robocupssl/ssl-vision-client:1.7.3
+  #   command:
+  #     - "-visionAddress"
+  #     - "224.5.23.2:10006"
+  #   restart: unless-stopped
+  #   ports:
+  #     - 8082/tcp
+  #     - 8082:8082
+  #   logging:
+  #     driver: none
+  #   network_mode: host
 
   # autoref-tigers:
   #   container_name: autoref-tigers
@@ -165,7 +165,7 @@ services:
     depends_on:
       - gateway
     network_mode: "host"
-    attach: true
+    attach: false
     
 volumes:
   .ssl-core:

--- a/docker-compose.cbr.yaml
+++ b/docker-compose.cbr.yaml
@@ -78,6 +78,7 @@ services:
     network_mode: host
     extra_hosts:
       - "playback-db:127.0.0.1"
+    attach: false
 
   player-bff:
     container_name: player-bff
@@ -164,7 +165,7 @@ services:
     depends_on:
       - gateway
     network_mode: "host"
-    attach: false
+    attach: true
     
 volumes:
   .ssl-core:

--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -209,7 +209,7 @@ services:
       dockerfile: navigation-ms/navigation-luffy/navigation-luffy.Dockerfile
     volumes:
       - .ssl-core:/tmp/.ssl-core
-    attach: true
+    attach: false
 
   decision-ms:
     container_name: decision-ms
@@ -242,7 +242,7 @@ services:
     depends_on:
       - gateway
     network_mode: "host"
-    attach: false
+    attach: true
 
 
 volumes:

--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -230,7 +230,7 @@ services:
       dockerfile: behavior-ms/behavior-bruxo/behavior-bruxo.Dockerfile
     volumes:
       - .ssl-core:/tmp/.ssl-core
-    attach: false
+    attach: true
   
   communication-ms:
     container_name: communication-ms
@@ -242,7 +242,7 @@ services:
     depends_on:
       - gateway
     network_mode: "host"
-    attach: true
+    attach: false
 
 
 volumes:

--- a/docker-compose.vision.yaml
+++ b/docker-compose.vision.yaml
@@ -1,0 +1,14 @@
+services:
+  ssl-vision-client:
+    container_name: ssl-vision-client
+    image: robocupssl/ssl-vision-client:1.7.3
+    command:
+      - "-visionAddress"
+      - "224.5.23.2:10006"
+    restart: unless-stopped
+    ports:
+      - 8082/tcp
+      - 8082:8082
+    logging:
+      driver: none
+    network_mode: host

--- a/navigation-ms/navigation-luffy/navigation/messaging/receiver/payload_mapper.cpp
+++ b/navigation-ms/navigation-luffy/navigation/messaging/receiver/payload_mapper.cpp
@@ -33,7 +33,7 @@ Payload PayloadMapper::fromZmqDatagrams(std::span<const ZmqDatagram> messages) c
     if (zmq_datagram.topic() == service_discovery::kBehaviorUnificationTopic) {
       rc::Behavior behavior;
       behavior.ParseFromString(std::string{zmq_datagram.message()});
-      // ilog("Received from behavior: {}", behavior.DebugString());
+      ilog("Received from behavior: {}", behavior.DebugString());
       behaviors.emplace_back(std::move(behavior));
     }
     if (zmq_datagram.topic() == service_discovery::kPerceptionDetectionTopic) {


### PR DESCRIPTION
Este pull request adiciona um Atacante simples que vai até a bola e ativa o peripheral actuation para chutar.

- Testado em ambiente controlado, não testado em campo
- O controle inicia no behavior-ms e gera o output para navegação
- Navegação utiliza o GoToPoint motion parser
- Comunicação envia todos campos produzidos pela navegação e behavior, exceto atuação do Dribbler.